### PR TITLE
Add pcb connectors

### DIFF
--- a/YAPP_Template.scad
+++ b/YAPP_Template.scad
@@ -195,6 +195,19 @@ connectors   =  [
                     [8, 8, 2.5, 3.8, 5, yappAllCorners]
                   , [30, 8, 5, 5, 5]
                 ];
+                
+//-- connectorsPCB -- origin = pcb[0,0,0]
+//-- a connector that allows to screw base and lid together through holes in the PCB
+// (0) = posx
+// (1) = posy
+// (2) = screwDiameter
+// (3) = insertDiameter
+// (4) = outsideDiameter
+// (5) = { yappAllCorners }
+connectorsPCB   =  [
+                    [pcbLength/2, 10, 2.5, 3.8, 5]
+                   ,[pcbLength/2, pcbWidth-10, 2.5, 3.8, 5]
+                ];
 
 //-- base mounts -- origen = box[x0,y0]
 // (0) = posx | posy

--- a/library/YAPPgenerator_v14.scad
+++ b/library/YAPPgenerator_v14.scad
@@ -1830,7 +1830,7 @@ module connector(plane, isPcb, x, y, d1, d2, d3)
   {
     translate([x, y, 0])
     {
-      hb = isPcb ? (baseWallHeight+basePlaneThickness-pcbThickness) : (baseWallHeight+basePlaneThickness);
+      hb = isPcb ? (standoffHeight+basePlaneThickness) : (baseWallHeight+basePlaneThickness);
       //echo("YAPP:", isPcb=isPcb);
       //echo("YAPP:", hb=hb);
    
@@ -1861,9 +1861,16 @@ module connector(plane, isPcb, x, y, d1, d2, d3)
   
   if (plane=="lid")
   {
-    translate([x, y, (lidWallHeight+lidPlaneThickness)*-1])
+    // calculate the Z-position for the lid connector.
+    // for a PCB connector, start the connector on top of the PCB to push it down.
+    // calculation identical to the one used in pcbPushdowns()
+
+    zTemp      = isPcb ? ((pcbZlid)*-1) : ((lidWallHeight+lidPlaneThickness)*-1);
+    heightTemp = isPcb ? ((baseWallHeight+lidWallHeight) - (standoffHeight+pcbThickness)) : lidWallHeight;
+
+    translate([x, y, zTemp])
     {
-      ht=(lidWallHeight);
+      ht=(heightTemp);
 
       difference()
       {


### PR DESCRIPTION
This adds a new connector type to connect the base and lid of the housing and also holding the PCB in one go.
Height calculation is copied from pcbPushdowns()
Example connectorsPCB[] added to YAPP_Template.scad
Backwards compatibility checked