### PR TITLE
Fixed standoff logic to account for standoff support dimensions

### DIFF
--- a/YAPP_testBox.scad
+++ b/YAPP_testBox.scad
@@ -1,7 +1,7 @@
 //---------------------------------------------------------
 // This design is parameterized based on the size of a PCB.
 //---------------------------------------------------------
-include <./library/YAPPgenerator_v14.scad>
+include <./library/YAPPgenerator_v16.scad>
 
 // Note: length/lengte refers to X axis, 
 //       width/breedte to Y, 

--- a/library/YAPPgenerator_v16.scad
+++ b/library/YAPPgenerator_v16.scad
@@ -89,6 +89,8 @@ standoffHeight      = 3.0;
 pinDiameter         = 2.0;
 pinHoleSlack        = 0.2;
 standoffDiameter    = 4;
+maxStandoffSupportHeight = 3.0;
+standoffSupportDiameter = 3.0;
 
 
 //-- D E B U G -----------------//-> Default ---------
@@ -1137,7 +1139,7 @@ module cutoutsInXY(type)
           }
         } //  for ..
 
-	      for(conn = connectorsPCB)
+        for(conn = connectorsPCB)
         {
           //-- [0] x-pos
           //-- [1] y-pos
@@ -2010,18 +2012,46 @@ module pcbStandoff(color, height, type, plane)
           {
             translate([0,0,-0.3]) 
             {
-              cylinder(h=2, r1=(standoffDiameter/2)+3, r2=standoffDiameter/2);
+                if (standoffHeight > maxStandoffSupportHeight)
+                {
+                    cylinder(h=maxStandoffSupportHeight, r1=(standoffDiameter/2)+standoffSupportDiameter, r2=standoffDiameter/2);
+                }
+                else
+                {
+                    cylinder(h=standoffHeight, r1=(standoffDiameter/2)+standoffSupportDiameter, r2=standoffDiameter/2);
+                }
             }
           }
           if (plane == "lid")
           {
-            //translate([0,0,lidWallHeight]) 
-            zP = height-1.8;//+standoffHeight-lidPlaneThickness;
-            translate([0,0,height-1.8]) 
-            {
-              //echo("Lid ..", height=height, zP=zP);
-              cylinder(h=2, r1=standoffDiameter/2, r2=(standoffDiameter/2)+3);
-            }
+              if (standoffHeight < maxStandoffSupportHeight)
+              {
+                  translate([0,0,height-1.8])
+                  {
+                        if (standoffHeight > maxStandoffSupportHeight)
+                        {
+                            cylinder(h=maxStandoffSupportHeight, r1=standoffDiameter/2, r2=(standoffDiameter/2)+standoffSupportDiameter);
+                        }
+                        else
+                        {
+                            cylinder(h=standoffHeight, r1=standoffDiameter/2, r2=(standoffDiameter/2)+standoffSupportDiameter);
+                        }
+                   }
+              }
+              else
+              {
+                  translate([0,0,height-maxStandoffSupportHeight])
+                  {
+                        if (standoffHeight > maxStandoffSupportHeight)
+                        {
+                            cylinder(h=maxStandoffSupportHeight, r1=standoffDiameter/2, r2=(standoffDiameter/2)+standoffSupportDiameter);
+                        }
+                        else
+                        {
+                            cylinder(h=standoffHeight, r1=standoffDiameter/2, r2=(standoffDiameter/2)+standoffSupportDiameter);
+                        }
+                  }
+              }
           }
 
         } // standoff()


### PR DESCRIPTION
I found an issue in v16 where the supports around the standoffs were configured statically. This patch adds two parameters to control the standoff supports on both the top and bottom covers. The bug is most obvious when you try and make the standoff height < 2.0. You'll notice that the standoff height doesn't decrease. As a consequence of this bug, the script will eat into the PCB thickness, resulting in standoffs that are too close together and don't give the PCB enough space. I noticed this issue because I unknowingly set the PCB thickness to 1.6mm and standoff height to 1mm. The standoffs did not shrink to reflect the changes. 