### PR TITLE
moved the calls back

### DIFF
--- a/library/YAPPgenerator_v21.scad
+++ b/library/YAPPgenerator_v21.scad
@@ -2745,12 +2745,6 @@ module lidShell()
 
   pcbPushdowns();
   shellConnectors("lid");
-
-  // Moved to lidShell so they can be cut for inspection
-  lidHookOutside();
-  buildLightTubes();  //-2.0-
-  buildButtons();     //-2.0-
-  lidHookInside();
   
 } //  lidShell()
 
@@ -3265,10 +3259,9 @@ module YAPPgenerate()
             {
               translate([0, (5 + shellWidth+(shiftLid/2))*-2, 0])
               {
-                // Moved inside lidShell() so they can be cut by the inspection planes
-                //buildLightTubes();  //-2.0-
-                //buildButtons();     //-2.0-
-                //lidHookInside();
+                buildLightTubes();  //-2.0-
+                buildButtons();     //-2.0-
+                lidHookInside();
                 
                 difference()  // (t1) 
                 {
@@ -3352,11 +3345,10 @@ module YAPPgenerate()
           translate([0, 0, (baseWallHeight+basePlaneThickness+
                             lidWallHeight+lidPlaneThickness+onLidGap)])
           {
-            // Moved inside lidShell() so they can be cut by the inspection planes
-            //lidHookOutside();
-            //buildLightTubes();  //-2.0-
-            //buildButtons();     //-2.0-    
-            //lidHookInside();
+            lidHookOutside();
+            buildLightTubes();  //-2.0-
+            buildButtons();     //-2.0-    
+            lidHookInside();
 
             difference()  // (t2)
             {


### PR DESCRIPTION
I moved the calls for lidHookOutside();   buildLightTubes(); buildButtons(); lidHookInside(); back to the original locations.  This fixed the button issue.

But it does break (well maybe not break but change) the inspectx/y functionality. But I do see that you had separate inspect options for the light tubes and buttons so having them as part of the inspect function wasn't there before.  If I get a chance I may look at how to get the inspectx/y working for everything but as you have the other options it's probably not necessary.

The inside/outside functions do not work still.  If I have a chance to look at that more later I will.  

Will probably look at adding fillets to the button recess also. 
![image](https://github.com/mrWheel/YAPP_Box/assets/33765928/03362db1-40ae-4866-97f0-085ec737a05e)
![image](https://github.com/mrWheel/YAPP_Box/assets/33765928/a49c138f-8a98-48b3-8ddb-c30647ce9e18)


