### PR TITLE
Change Coord defaults

### DIFF
--- a/GateAlarm_Sample_v30.scad
+++ b/GateAlarm_Sample_v30.scad
@@ -90,7 +90,7 @@ standoffDiameter    = 4.0;
 
 
 //-- C O N T R O L -------------//-> Default ---------
-showSideBySide      = false;     //-> true
+showSideBySide      = true;     //-> true
 previewQuality      = 5;        //-> from 1 to 32, Default = 5
 renderQuality       = 12;       //-> from 1 to 32, Default = 8
 onLidGap            = 10;
@@ -230,7 +230,7 @@ baseMounts =
 //    (n) = { yappPolygonDef } : Required if shape = yappPolygon specified -
 //    (n) = { yappMaskDef } : If a yappMaskDef object is added it will be used as a mask for the cutout.
 //    (n) = { [yappMaskDef, hOffset, vOffset, rotations] } : If a list for a mask is added it will be used as a mask for the cutout. With the Rotation and offsets applied. THis can be used to fine tune the mask placement in the opening.
-//    (n) = { <yappCoordBox> | yappCoordPCB }
+//    (n) = { yappCoordBox | <yappCoordPCB> }
 //    (n) = { <yappOrigin>, yappCenter }
 //  (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top, Back and Right Faces
 //-------------------------------------------------------------------
@@ -244,7 +244,7 @@ cutoutsBase =
 cutoutsLid  = 
 [
   // Cutout for piezo buzzer
-  [25,shellWidth/2 ,0,0, 29.8/2, yappCircle ,yappCenter] 
+  [25,shellWidth/2 ,0,0, 29.8/2, yappCircle ,yappCenter, yappCoordBox] 
 ];
 
 cutoutsFront =  
@@ -256,7 +256,7 @@ cutoutsFront =
 cutoutsBack = 
 [
   // Cutout for USB
- [pcbWidth/2, -5 -pcbThickness ,12.5,7.0, 2, yappRoundedRect , yappCenter, yappCoordPCB]
+ [pcbWidth/2, -5 -pcbThickness ,12.5,7.0, 2, yappRoundedRect , yappCenter]
 ];
 
 cutoutsLeft =   
@@ -269,7 +269,7 @@ cutoutsRight =
   //Cutout for cable
 //  [35,6 ,0,0, 3.25, yappCircle,yappCenter]
   // Make the hole thru the end of the ridge extansion
-  [35+3.25,ridgeExtTop-8, 0,  0,  3.25, yappCircle, yappCenter]
+  [35+3.25,6, 0,  0,  3.25, yappCircle, yappCenter, yappCoordBox]
 
 ];
 
@@ -327,37 +327,42 @@ lightTubes =
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
+    undef,undef,1
   ]
  ,[pcbLength-(8.820+(2.54*3)),(pcbWidth/2)-1.27 - (2.54*1), // Pos
     6, 6,                 // W,L
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
-//    ,0,undef,0.5    //
+    undef,undef,1
   ]
  ,[pcbLength-(8.820+(2.54*6)),(pcbWidth/2)-3.810, // Pos
     6, 6,                 // W,L
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
+    undef,undef,1
   ]
  ,[pcbLength-(8.820+(2.54*9)),(pcbWidth/2)-3.810, // Pos
     6, 6,                 // W,L
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
+    undef,undef,1
   ]
  ,[pcbLength-(8.820),(pcbWidth/2)+3.810, // Pos
     6, 6,                 // W,L
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
+    undef,undef,1
   ]
  ,[pcbLength-(8.820+(2.54*3)),(pcbWidth/2)+3.810, // Pos
     6, 6,                 // W,L
     1.0,                      // wall thickness
     2,                      // Gap above PCB
     yappCircle,          // tubeType (Shape)
+    undef,undef,1
   ]
 ];
 
@@ -393,7 +398,7 @@ pushButtons =
     3.5, // Pole Diameter
     undef, // Height to top of PCB
     yappCircle, // Shape
-    0.01
+    0
     ]
 ];
     
@@ -408,9 +413,11 @@ pushButtons =
 //   Required:
 //    (0) = pos
 //    (1) = width
-//    (2) = height : Distance below the ridge : Negative to move into lid
+//    (2) = height : Where to relocate the seam : yappCoordPCB = Above (positive) the PCB
+//                                                yappCoordBox = Above (positive) the bottom of the shell (outside)
 //   Optional:
 //    (n) = { <yappOrigin>, yappCenter } 
+//    (n) = { yappCoordBox, <yappCoordPCB> }
 //    (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
 
 // Note: use ridgeExtTop to reference the top of the extension for cutouts.
@@ -434,7 +441,7 @@ ridgeExtLeft =
 ridgeExtRight =
 [
   // Make a ridge extension 6mm wide 10mm below the top of the ridge
-  [35, 6.5, 8]
+  [35, 6.5, 6, yappCoordBox]
  ];
 
     

--- a/YAPP_HookTest_v30.scad
+++ b/YAPP_HookTest_v30.scad
@@ -1,0 +1,339 @@
+//-----------------------------------------------------------------------
+// Yet Another Parameterized Projectbox generator
+//
+//  This is a box for <template>
+//
+//  Version 3.0 (01-12-2023)
+//
+// This design is parameterized based on the size of a PCB.
+//
+//  You might need to adjust the number of elements:
+//
+//      Preferences->Advanced->Turn of rendering at 250000 elements
+//                                                  ^^^^^^
+//
+//-----------------------------------------------------------------------
+
+include <../YAPP_Box/library/YAPPgenerator_v30.scad>
+
+//---------------------------------------------------------
+// This design is parameterized based on the size of a PCB.
+//---------------------------------------------------------
+// Note: length/lengte refers to X axis, 
+//       width/breedte to Y, 
+//       height/hoogte to Z
+
+/*
+      padding-back|<------pcb length --->|<padding-front
+                            RIGHT
+        0    X-axis ---> 
+        +----------------------------------------+   ---
+        |                                        |    ^
+        |                                        |   padding-right 
+      Y |                                        |    v
+      | |    -5,y +----------------------+       |   ---              
+ B    a |         | 0,y              x,y |       |     ^              F
+ A    x |         |                      |       |     |              R
+ C    i |         |                      |       |     | pcb width    O
+ K    s |         |                      |       |     |              N
+        |         | 0,0              x,0 |       |     v              T
+      ^ |    -5,0 +----------------------+       |   ---
+      | |                                        |    padding-left
+      0 +----------------------------------------+   ---
+        0    X-as --->
+                          LEFT
+*/
+
+//-- which part(s) do you want to print?
+printBaseShell        = true;
+printLidShell         = true;
+printSwitchExtenders  = true;
+
+//-- pcb dimensions -- very important!!!
+pcbLength           = 150; // Front to back
+pcbWidth            = 100; // Side to side
+pcbThickness        = 1.6;
+                            
+//-- padding between pcb and inside wall
+paddingFront        = 1;
+paddingBack         = 1;
+paddingRight        = 1;
+paddingLeft         = 1;
+
+//-- Edit these parameters for your own box dimensions
+wallThickness       = 4.0;
+basePlaneThickness  = 1.5;
+lidPlaneThickness   = 1.5;
+
+//-- Total height of box = lidPlaneThickness 
+//                       + lidWallHeight 
+//                       + baseWallHeight 
+//                       + basePlaneThickness
+//-- space between pcb and lidPlane :=
+//--      (bottonWallHeight+lidWallHeight) - (standoffHeight+pcbThickness)
+baseWallHeight      = 25;
+lidWallHeight       = 25;
+
+//-- ridge where base and lid off box can overlap
+//-- Make sure this isn't less than lidWallHeight 
+//     or 1.8x wallThickness if using snaps
+ridgeHeight         = 10.0;
+ridgeSlack          = 0.2;
+
+//-- Radius of the shell corners
+roundRadius         = 3;
+
+//-- How much the PCB needs to be raised from the base
+//-- to leave room for solderings and whatnot
+standoffHeight      = 10.0;  //-- used for PCB Supports, Push Button and showPCB
+standoffDiameter    = 7;
+standoffPinDiameter = 2.4;
+standoffHoleSlack   = 0.4;
+
+//-- C O N T R O L -------------//-> Default ---------
+showSideBySide      = true;     //-> true
+previewQuality      = 5;        //-> from 1 to 32, Default = 5
+renderQuality       = 8;        //-> from 1 to 32, Default = 8
+onLidGap            = 12;
+shiftLid            = 5;
+colorLid            = "YellowGreen";   
+alphaLid            = 1;
+colorBase           = "BurlyWood";
+alphaBase           = 1;
+hideLidWalls        = false;    //-> false
+hideBaseWalls       = false;    //-> false
+showOrientation     = true;
+showPCB             = false;
+showSwitches        = false;
+showPCBmarkers      = false;
+showShellZero       = false;
+showCenterMarkers   = false;
+inspectX            = 0;        //-> 0=none (>0 from Back)
+inspectY            = 0;        //-> 0=none (>0 from Right)
+inspectZ            = 0;        //-> 0=none (>0 from Bottom)
+inspectXfromBack    = true;     //-> View from the inspection cut foreward
+inspectYfromLeft    = true;     //-> View from the inspection cut to the right
+inspectZfromTop     = false;    //-> View from the inspection cut down
+//-- C O N T R O L ---------------------------------------
+
+
+//===================================================================
+//  *** Cutouts ***
+//    There are 6 cutouts one for each surface:
+//      cutoutsBase (Bottom), cutoutsLid (Top), cutoutsFront, cutoutsBack, cutoutsLeft, cutoutsRight
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//                        Required                Not Used        Note
+//                      +-----------------------+---------------+------------------------------------
+//  yappRectangle       | width, length         | radius        |
+//  yappCircle          | radius                | width, length |
+//  yappRoundedRect     | width, length, radius |               |     
+//  yappCircleWithFlats | width, radius         | length        | length=distance between flats
+//  yappCircleWithKey   | width, length, radius |               | width = key width length=key depth
+//  yappPolygon         | width, length         | radius        | yappPolygonDef object must be provided
+//
+//  Parameters:
+//   Required:
+//    (0) = from Back
+//    (1) = from Left
+//    (2) = width
+//    (3) = length
+//    (4) = radius
+//    (5) = shape : {yappRectangle | yappCircle | yappPolygon | yappRoundedRect | yappCircleWithFlats | yappCircleWithKey}
+//  Optional:
+//    (6) = depth : Default = 0/Auto : 0 = Auto (plane thickness)
+//    (7) = angle : Default = 0
+//    (n) = { yappPolygonDef } : Required if shape = yappPolygon specified -
+//    (n) = { yappMaskDef } : If a yappMaskDef object is added it will be used as a mask for the cutout.
+//    (n) = { [yappMaskDef, hOffset, vOffset, rotation] } : If a list for a mask is added it will be used as a mask for the cutout. With the Rotation and offsets applied. This can be used to fine tune the mask placement within the opening.
+//    (n) = { <yappCoordBox> | yappCoordPCB }
+//    (n) = { <yappOrigin>, yappCenter }
+//  (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+
+//    (n) = { <yappBoth> | yappLidOnly | yappBaseOnly } : What part of the shell to cut (only affects Left/Right/Front/Back
+
+
+//-------------------------------------------------------------------
+
+cutoutsBase = 
+[
+
+];
+
+cutoutsLid  = 
+[
+];
+
+cutoutsFront =  
+[
+
+];
+
+
+cutoutsBack = 
+[
+  // Make the hole thru the end of the ridge extansion
+  [25,ridgeExtTop-10-3, 0,  0,  3, yappCircle]
+];
+
+cutoutsLeft =   
+[
+
+];
+
+cutoutsRight =  
+[
+
+];
+
+
+//===================================================================
+//  *** Ridge Extension ***
+//    Extension from the lid into the case for adding split opening at various heights
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//  Parameters:
+//   Required:
+//    (0) = pos
+//    (1) = width
+//    (2) = height : Distance below the ridge : Negative to move into lid
+//   Optional:
+//    (n) = { <yappOrigin>, yappCenter } 
+//    (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+
+// Note: use ridgeExtTop to reference the top of the extension for cutouts.
+// Note: Snaps should not be placed on ridge extensions as they remove the ridge to place them.
+//-------------------------------------------------------------------
+ridgeExtFront =
+[
+ [85, 6, ridgeHeight]
+  
+  // Make a ridge extension 6mm wide in the middle of the ridge 
+ ,[95, 6, 5]
+   
+  // Make a ridge extension 6mm wide 10mm below the top of the ridge
+ ,[25, 6, 10]
+  
+  // Make a ridge extension 20mm wide 15mm below the top of the ridge
+ ,[45, 20, 15]
+ 
+ // Make a ridge extension 6mm wide 15mm below the top of the ridge
+ ,[35, 6, 15]
+];
+
+ridgeExtBack =
+[
+ 
+];
+
+ridgeExtLeft =
+[
+ 
+];
+
+ridgeExtRight =
+[
+
+];
+
+
+  
+  
+//===================================================================
+//  *** Labels ***
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//  Parameters:
+//   (0) = posx
+//   (1) = posy/z
+//   (2) = rotation degrees CCW
+//   (3) = depth : positive values go into case (Remove) negative valies are raised (Add)
+//   (4) = plane {yappLeft | yappRight | yappFront | yappBack | yappTop | yappBottom}
+//   (5) = font
+//   (6) = size
+//   (7) = "label text"
+//-------------------------------------------------------------------
+labelsPlane =
+[
+
+];
+//========= HOOK functions ============================
+  
+// Hook functions allow you to add 3d objects to the case.
+// Lid/Base = Shell part to attach the object to.
+// Inside/Outside = Join the object from the midpoint of the shell to the inside/outside.
+// Pre = Attach the object Pre before doing Cutouts/Stands/Connectors. 
+
+//===========================================================
+// origin = box(0,0,0)
+module hookLidInsidePre()
+{
+  echo("hookLidInsidePre() ..");
+  translate([shellInsideLength, shellInsideWidth, 0]) sphere(20);
+} // hookLidInsidePre()
+
+//===========================================================
+// origin = box(0,0,0)
+module hookLidInside()
+{
+  echo("hookLidInside() ..");
+  sphere(20);
+} // hookLidInside()
+  
+//===========================================================
+//===========================================================
+// origin = box(0,0,shellHeight)
+module hookLidOutsidePre()
+{
+  echo("hookLidOutsidePre() ..");
+  translate([shellInsideLength, shellInsideWidth, 0]) sphere(20);
+} // hookLidOutsidePre()
+
+//===========================================================
+// origin = box(0,0,shellHeight)
+module hookLidOutside()
+{
+  echo("hookLidOutside() ..");
+  sphere(20);
+} // hookLidOutside()
+
+//===========================================================
+//===========================================================
+// origin = box(0,0,0)
+module hookBaseInsidePre()
+{
+  echo("hookBaseInsidePre() ..");
+} // hookBaseInsidePre()
+
+//===========================================================
+// origin = box(0,0,0)
+module hookBaseInside()
+{
+  echo("hookBaseInside() ..");
+  sphere(20);
+} // hookBaseInside()
+
+//===========================================================
+//===========================================================
+// origin = box(0,0,0)
+module hookBaseOutsidePre()
+{
+  echo("hookBaseOutsidePre() ..");
+} // hookBaseOutsidePre()
+
+//===========================================================
+// origin = box(0,0,0)
+module hookBaseOutside()
+{
+  echo("hookBaseOutside() ..");
+  sphere(20);
+} // hookBaseOutside()
+
+//===========================================================
+//===========================================================
+
+//---- This is where the magic happens ----
+YAPPgenerate();

--- a/YAPP_RidgeExtDemo_v30.scad
+++ b/YAPP_RidgeExtDemo_v30.scad
@@ -1,0 +1,381 @@
+//-----------------------------------------------------------------------
+// Yet Another Parameterized Projectbox generator
+//
+//  This is a box for <template>
+//
+//  Version 3.0 (01-12-2023)
+//
+// This design is parameterized based on the size of a PCB.
+//
+//  You might need to adjust the number of elements:
+//
+//      Preferences->Advanced->Turn of rendering at 250000 elements
+//                                                  ^^^^^^
+//
+//-----------------------------------------------------------------------
+
+include <../YAPP_Box/library/YAPPgenerator_v30.scad>
+
+//---------------------------------------------------------
+// This design is parameterized based on the size of a PCB.
+//---------------------------------------------------------
+// Note: length/lengte refers to X axis, 
+//       width/breedte to Y, 
+//       height/hoogte to Z
+
+/*
+      padding-back|<------pcb length --->|<padding-front
+                            RIGHT
+        0    X-axis ---> 
+        +----------------------------------------+   ---
+        |                                        |    ^
+        |                                        |   padding-right 
+      Y |                                        |    v
+      | |    -5,y +----------------------+       |   ---              
+ B    a |         | 0,y              x,y |       |     ^              F
+ A    x |         |                      |       |     |              R
+ C    i |         |                      |       |     | pcb width    O
+ K    s |         |                      |       |     |              N
+        |         | 0,0              x,0 |       |     v              T
+      ^ |    -5,0 +----------------------+       |   ---
+      | |                                        |    padding-left
+      0 +----------------------------------------+   ---
+        0    X-as --->
+                          LEFT
+*/
+
+//-- which part(s) do you want to print?
+printBaseShell        = true;
+printLidShell         = true;
+printSwitchExtenders  = true;
+
+//-- pcb dimensions -- very important!!!
+pcbLength           = 150; // Front to back
+pcbWidth            = 100; // Side to side
+pcbThickness        = 1.6;
+                            
+//-- padding between pcb and inside wall
+paddingFront        = 1;
+paddingBack         = 1;
+paddingRight        = 1;
+paddingLeft         = 1;
+
+//-- Edit these parameters for your own box dimensions
+wallThickness       = 4.0;
+basePlaneThickness  = 1.5;
+lidPlaneThickness   = 1.5;
+
+//-- Total height of box = lidPlaneThickness 
+//                       + lidWallHeight 
+//                       + baseWallHeight 
+//                       + basePlaneThickness
+//-- space between pcb and lidPlane :=
+//--      (bottonWallHeight+lidWallHeight) - (standoffHeight+pcbThickness)
+baseWallHeight      = 25;
+lidWallHeight       = 25;
+
+//-- ridge where base and lid off box can overlap
+//-- Make sure this isn't less than lidWallHeight 
+//     or 1.8x wallThickness if using snaps
+ridgeHeight         = 10.0;
+ridgeSlack          = 0.2;
+
+//-- Radius of the shell corners
+roundRadius         = 3;
+
+//-- How much the PCB needs to be raised from the base
+//-- to leave room for solderings and whatnot
+standoffHeight      = 10.0;  //-- used for PCB Supports, Push Button and showPCB
+standoffDiameter    = 7;
+standoffPinDiameter = 2.4;
+standoffHoleSlack   = 0.4;
+
+//-- C O N T R O L -------------//-> Default ---------
+showSideBySide      = false;     //-> true
+previewQuality      = 5;        //-> from 1 to 32, Default = 5
+renderQuality       = 8;        //-> from 1 to 32, Default = 8
+onLidGap            = 12;
+shiftLid            = 5;
+colorLid            = "YellowGreen";   
+alphaLid            = 1;
+colorBase           = "BurlyWood";
+alphaBase           = 1;
+hideLidWalls        = false;    //-> false
+hideBaseWalls       = false;    //-> false
+showOrientation     = true;
+showPCB             = false;
+showSwitches        = false;
+showPCBmarkers      = false;
+showShellZero       = false;
+showCenterMarkers   = false;
+inspectX            = 0;        //-> 0=none (>0 from Back)
+inspectY            = 0;        //-> 0=none (>0 from Right)
+inspectZ            = 0;        //-> 0=none (>0 from Bottom)
+inspectXfromBack    = true;     //-> View from the inspection cut foreward
+inspectYfromLeft    = true;     //-> View from the inspection cut to the right
+inspectZfromTop     = false;    //-> View from the inspection cut down
+//-- C O N T R O L ---------------------------------------
+
+
+//===================================================================
+//  *** Cutouts ***
+//    There are 6 cutouts one for each surface:
+//      cutoutsBase (Bottom), cutoutsLid (Top), cutoutsFront, cutoutsBack, cutoutsLeft, cutoutsRight
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//                        Required                Not Used        Note
+//                      +-----------------------+---------------+------------------------------------
+//  yappRectangle       | width, length         | radius        |
+//  yappCircle          | radius                | width, length |
+//  yappRoundedRect     | width, length, radius |               |     
+//  yappCircleWithFlats | width, radius         | length        | length=distance between flats
+//  yappCircleWithKey   | width, length, radius |               | width = key width length=key depth
+//  yappPolygon         | width, length         | radius        | yappPolygonDef object must be provided
+//
+//  Parameters:
+//   Required:
+//    (0) = from Back
+//    (1) = from Left
+//    (2) = width
+//    (3) = length
+//    (4) = radius
+//    (5) = shape : {yappRectangle | yappCircle | yappPolygon | yappRoundedRect | yappCircleWithFlats | yappCircleWithKey}
+//  Optional:
+//    (6) = depth : Default = 0/Auto : 0 = Auto (plane thickness)
+//    (7) = angle : Default = 0
+//    (n) = { yappPolygonDef } : Required if shape = yappPolygon specified -
+//    (n) = { yappMaskDef } : If a yappMaskDef object is added it will be used as a mask for the cutout.
+//    (n) = { [yappMaskDef, hOffset, vOffset, rotation] } : If a list for a mask is added it will be used as a mask for the cutout. With the Rotation and offsets applied. This can be used to fine tune the mask placement within the opening.
+//    (n) = { yappCoordBox | <yappCoordPCB> }
+//    (n) = { <yappOrigin>, yappCenter }
+//  (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+
+//    (n) = { <yappBoth> | yappLidOnly | yappBaseOnly } : What part of the shell to cut (only affects Left/Right/Front/Back
+
+
+//-------------------------------------------------------------------
+
+cutoutsBase = 
+[
+
+];
+
+cutoutsLid  = 
+[
+];
+
+cutoutsFront =  
+[
+  // This can only have a cable put through it after the case is assembled
+  // This could be used as a locking pin
+  [75,(ridgeHeight/2), 0,  0,  1, yappCircle, yappCenter]
+  
+  // Make the hole thru the end of the ridge extansion
+ ,[85,ridgeHeight-3, 0,  0,  3, yappCircle]
+ 
+  // In the Middle of the Ridge
+ ,[95+3,(ridgeHeight/2), 0,  0,  2.5, yappCircle, yappCenter]
+
+  // Make the hole thru the end of the ridge extansion
+ ,[25,10-3, 0,  0,  3, yappCircle]
+
+  // Make the rounded rect thru the end of the ridge extansion
+ ,[45, 15-3, 20, 6,  3, yappRoundedRect]
+
+  // Make the hexagonal thru the end of the ridge extansion
+ ,[38, 15, 6, 6,  0, yappPolygon, 0, 30, shapeHexagon, yappCenter]
+
+
+];
+
+
+cutoutsBack = 
+[
+  // Make the hole thru the end of the ridge extansion
+  [28,8, 0,  0,  3, yappCircle, yappCenter, yappCoordBox]
+
+  // Make the hole thru the end of the ridge extansion
+ ,[28,8, 6,  6,  0, yappPolygon, shape6ptStar, yappLeftOrigin, yappCenter, yappCoordBox]
+
+  // Make the rounded rect thru the end of the ridge extansion
+ ,[55,13, 20, 6,  3, yappRoundedRect, yappCenter, yappCoordBox]
+
+  // Make the hexagonal thru the end of the ridge extansion
+ ,[38,35, 6, 6,  0, yappPolygon, 0, 30, shapeHexagon, yappCenter, yappCoordBox]
+
+
+];
+
+cutoutsLeft =   
+[
+  // Make the hole thru the end of the ridge extansion
+  // Height = ridgeExtTop - height of the ext - the diameter of the circle
+  [5,10-3, 0,  0,  3, yappCircle]
+
+  // Make the hexagonal thru the end of the ridge extansion
+ ,[15+3,15, 6, 6,  0, yappPolygon, 0, 30, shapeHexagon, yappCenter]
+
+  // Make the rounded rect thru the end of the ridge extansion
+ ,[25,15-3, 10, 6,  3, yappRoundedRect]
+
+
+];
+
+cutoutsRight =  
+[
+  // Make the hole thru the end of the ridge extansion
+  [25,10-3, 0,  0,  3, yappCircle]
+
+  // Make the hole thru the end of the ridge extansion
+ ,[25,10-3, 6,  6,  0, yappPolygon, shape6ptStar, yappLeftOrigin]
+
+  // Make the rounded rect thru the end of the ridge extansion
+ ,[45,15-3, 20, 6,  3, yappRoundedRect]
+
+  // Make the hexagonal thru the end of the ridge extansion
+ ,[38,15, 6, 6,  0, yappPolygon, 0, 30, shapeHexagon, yappCenter]
+
+
+];
+
+
+//===================================================================
+//  *** Ridge Extension ***
+//    Extension from the lid into the case for adding split opening at various heights
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//  Parameters:
+//   Required:
+//    (0) = pos
+//    (1) = width
+//    (2) = height : Distance below the ridge : Negative to move into lid
+//   Optional:
+//    (n) = { <yappOrigin>, yappCenter } 
+//    (n) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+
+// Note: use ridgeExtTop to reference the top of the extension for cutouts.
+// Note: Snaps should not be placed on ridge extensions as they remove the ridge to place them.
+//-------------------------------------------------------------------
+ridgeExtFront =
+[
+ [85, 6, ridgeHeight]
+  
+  // Make a ridge extension 6mm wide in the middle of the ridge 
+ ,[95, 6, 5]
+   
+  // Make a ridge extension 6mm wide 10mm below the top of the ridge
+ ,[25, 6, 10]
+  
+  // Make a ridge extension 20mm wide 15mm below the top of the ridge
+ ,[45, 20, 15]
+ 
+ // Make a ridge extension 6mm wide 15mm below the top of the ridge
+ ,[35, 6, 15]
+];
+
+ridgeExtBack =
+[
+  // Make a ridge extension 6mm wide 8mm from the bottom of the box
+  [25, 6, 8, yappCoordBox]
+  
+  // Make a ridge extension 6mm wide 8mm from the bottom of the box from the left edge
+ ,[25, 6, 8, yappLeftOrigin, yappCoordBox]
+  
+  // Make a ridge extension 20mm wide 13mm from the bottom of the box
+ ,[45, 20, 13, yappCoordBox]
+ 
+ // Make a ridge extension 6mm wide 35mm from the bottom of the box
+ ,[35, 6, 35, yappCoordBox]
+];
+
+ridgeExtLeft =
+[
+  // Make a ridge extension 6mm wide 10mm below the top of the ridge
+  [5, 6, 10]
+  // Make a ridge extension 6mm wide 15mm below the top of the ridge
+ ,[15, 6, 15]
+  // Make a ridge extension 20mm wide 15mm below the top of the ridge
+ ,[25, 10, 15]
+ 
+ // Make a row of ridgeExt from 8mm below the PCB to 
+ ,[ 40, 5, -8]
+ ,[ 50, 5, -4]
+ ,[ 60, 5, -0]
+ ,[ 70, 5,  4]
+ ,[ 80, 5,  8]
+ ,[ 90, 5, 12]
+ ,[100, 5, 16]
+ ,[110, 5, 20]
+ ,[120, 5, 24]
+ ,[130, 5, 28]
+];
+
+ridgeExtRight =
+[
+  // Make a ridge extension 6mm wide 10mm below the top of the ridge
+  [25, 6, 10]
+  
+  // Make a ridge extension 6mm wide 10mm below the top of the ridge from the left edge
+ ,[25, 6, 10, yappLeftOrigin]
+  
+  // Make a ridge extension 20mm wide 15mm below the top of the ridge
+ ,[45, 20, 15]
+ 
+ // Make a ridge extension 6mm wide 15mm below the top of the ridge
+ ,[35, 6, 15]
+];
+
+
+  
+  
+//===================================================================
+//  *** Labels ***
+//-------------------------------------------------------------------
+//  Default origin = yappCoordBox: box[0,0,0]
+//
+//  Parameters:
+//   (0) = posx
+//   (1) = posy/z
+//   (2) = rotation degrees CCW
+//   (3) = depth : positive values go into case (Remove) negative valies are raised (Add)
+//   (4) = plane {yappLeft | yappRight | yappFront | yappBack | yappTop | yappBottom}
+//   (5) = font
+//   (6) = size
+//   (7) = "label text"
+//-------------------------------------------------------------------
+labelsPlane =
+[
+//  [5, 5, 0, 3, yappTop, "Liberation Mono:style=bold", 5, "YAPP Top" ]
+// ,[5, 5, 0, 3, yappBottom, "Liberation Mono:style=bold", 5, "YAPP Bottom" ]
+// ,[5, 5, 0, 3, yappLeft, "Liberation Mono:style=bold", 5, "YAPP Left" ]
+// ,[5, 5, 0, 3, yappRight, "Liberation Mono:style=bold", 5, "YAPP Right" ]
+// ,[5, 5, 0, 3, yappFront, "Liberation Mono:style=bold", 5, "YAPP Front" ]
+//  ,[5, 5, 0, 3, yappBack, "Liberation Mono:style=bold", 5, "YAPP Back" ]
+ 
+//  ,[10, 15, 45, 3, yappTop,    "Liberation Mono:style=bold", 5, "YAPP Top" ]
+//  ,[10, 15, 45, 3, yappBottom, "Liberation Mono:style=bold", 5, "YAPP Bottom" ]
+//  ,[10, 15, 45, 3, yappLeft,   "Liberation Mono:style=bold", 5, "YAPP Left" ]
+//  ,[10, 15, 45, 3, yappRight,  "Liberation Mono:style=bold", 5, "YAPP Right" ]
+//  ,[10, 15, 45, 3, yappFront,  "Liberation Mono:style=bold", 5, "YAPP Front" ]
+//  ,[10, 15, 45, 3, yappBack,   "Liberation Mono:style=bold", 5, "YAPP Back" ]
+
+//  ,[35, 5, 0, -2, yappTop, "Liberation Mono:style=bold", 5, "YAPP Top" ]
+//  ,[35, 5, 0, -2, yappBottom, "Liberation Mono:style=bold", 5, "YAPP Bottom" ]
+//  ,[35, 5, 0, -2, yappLeft, "Liberation Mono:style=bold", 5, "YAPP Left" ]
+//  ,[35, 5, 0, -2, yappRight, "Liberation Mono:style=bold", 5, "YAPP Right" ]
+//  ,[35, 5, 0, -2, yappFront, "Liberation Mono:style=bold", 5, "YAPP Front" ]
+//  ,[35, 5, 0, -2, yappBack, "Liberation Mono:style=bold", 5, "YAPP Back" ]
+ 
+//  ,[30, 15, 45, -2, yappTop,    "Liberation Mono:style=bold", 5, "YAPP Top" ]
+//  ,[30, 15, 45, -2, yappBottom, "Liberation Mono:style=bold", 5, "YAPP Bottom" ]
+//  ,[30, 15, 45, -2, yappLeft,   "Liberation Mono:style=bold", 5, "YAPP Left" ]
+//  ,[30, 15, 45, -2, yappRight,  "Liberation Mono:style=bold", 5, "YAPP Right" ]
+//  ,[30, 15, 45, -2, yappFront,  "Liberation Mono:style=bold", 5, "YAPP Front" ]
+//  ,[30, 15, 45, -2, yappBack,   "Liberation Mono:style=bold", 5, "YAPP Back" ]
+];
+
+
+//---- This is where the magic happens ----
+YAPPgenerate();

--- a/library/YAPPgenerator_v30.scad
+++ b/library/YAPPgenerator_v30.scad
@@ -71,10 +71,10 @@ pcbWidth            = 100; // Side to side
 pcbThickness        = 1.6;
                             
 //-- padding between pcb and inside wall
-paddingFront        = 1;
-paddingBack         = 1;
-paddingRight        = 1;
-paddingLeft         = 1;
+paddingFront        = 5;
+paddingBack         = 10;
+paddingRight        = 15;
+paddingLeft         = 20;
 
 //-- Edit these parameters for your own box dimensions
 wallThickness       = 2.0;
@@ -87,8 +87,8 @@ lidPlaneThickness   = 1.5;
 //                       + basePlaneThickness
 //-- space between pcb and lidPlane :=
 //--      (bottonWallHeight+lidWallHeight) - (standoffHeight+pcbThickness)
-baseWallHeight      = 25;
-lidWallHeight       = 25;
+baseWallHeight      = 12;
+lidWallHeight       = 11;
 
 //-- ridge where base and lid off box can overlap
 //-- Make sure this isn't less than lidWallHeight 
@@ -101,7 +101,7 @@ roundRadius         = 5;
 
 //-- How much the PCB needs to be raised from the base
 //-- to leave room for solderings and whatnot
-standoffHeight      = 10.0;  //-- used for PCB Supports, Push Button and showPCB
+standoffHeight      = 10.0;  //-- used for PCB Supports, Push Button and showPCB and whenever yappCoordPCB is used.
 standoffDiameter    = 7;
 standoffPinDiameter = 2.4;
 standoffHoleSlack   = 0.4;
@@ -110,7 +110,7 @@ standoffHoleSlack   = 0.4;
 showSideBySide      = true;     //-> true
 previewQuality      = 5;        //-> from 1 to 32, Default = 5
 renderQuality       = 8;        //-> from 1 to 32, Default = 8
-onLidGap            = 0;
+onLidGap            = 3;
 shiftLid            = 5;
 colorLid            = "YellowGreen";   
 alphaLid            = 1;
@@ -119,7 +119,7 @@ alphaBase           = 1;
 hideLidWalls        = false;    //-> false
 hideBaseWalls       = false;    //-> false
 showOrientation     = true;
-showPCB             = false;
+showPCB             = true;
 showSwitches        = false;
 showPCBmarkers      = false;
 showShellZero       = false;
@@ -431,7 +431,7 @@ connectors   =
 //                              it will be used as a mask for the cutout. With the Rotation 
 //                              and offsets applied. This can be used to fine tune the mask
 //                              placement within the opening.
-//    n(d) = { <yappCoordBox> | yappCoordPCB }
+//    n(d) = { yappCoordBox | <yappCoordPCB> }
 //    n(e) = { <yappOrigin>, yappCenter }
 //    n(f) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
 //-------------------------------------------------------------------
@@ -549,6 +549,18 @@ lightTubes =
 //-------------------------------------------------------------------
 pushButtons = 
 [
+   [pcbLength-(8.820+(2.54*8.5)),(pcbWidth/2)+3.810+(2.54*2), 
+    8, // cap Diameter
+    0, // Unused
+    1, // Cap above Lid
+    3, // Switch Height
+    1, // Switch travel
+    3.5, // Pole Diameter
+    undef, // Height to top of PCB
+    yappCircle, // Shape
+    0
+    ]
+
 ];
   
 
@@ -562,16 +574,18 @@ pushButtons =
 //   Required:
 //    p(0) = pos
 //    p(1) = width
-//    p(2) = height : Distance below the ridge : Negative to move into lid
+//    p(2) = height : Where to relocate the seam : yappCoordPCB = Above (positive) the PCB
+//                                                yappCoordBox = Above (positive) the bottom of the shell (outside)
 //   Optional:
 //    n(a) = { <yappOrigin>, yappCenter } 
-//    n(b) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
-
-// Note: use ridgeExtTop to reference the top of the extension for cutouts.
+//    n(b) = { yappCoordBox, <yappCoordPCB> }
+//    n(c) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+//
 // Note: Snaps should not be placed on ridge extensions as they remove the ridge to place them.
 //-------------------------------------------------------------------
 ridgeExtLeft =
 [
+
 ];
 
 ridgeExtRight =
@@ -580,10 +594,12 @@ ridgeExtRight =
 
 ridgeExtFront =
 [
-];
 
+];
+//qqqqq
 ridgeExtBack =
 [
+
 ];
   
   
@@ -604,8 +620,8 @@ ridgeExtBack =
 //-------------------------------------------------------------------
 labelsPlane =
 [
-];
 
+];
 
 
 //========= HOOK functions ============================
@@ -619,14 +635,14 @@ labelsPlane =
 // origin = box(0,0,0)
 module hookLidInsidePre()
 {
-  if (printMessages) echo("hookLidInsidePre() ..");
+  //if (printMessages) echo("hookLidInsidePre() ..");
 } // hookLidInsidePre()
 
 //===========================================================
 // origin = box(0,0,0)
 module hookLidInside()
 {
-  if (printMessages) echo("hookLidInside() ..");
+  //if (printMessages) echo("hookLidInside() ..");
 } // hookLidInside()
   
 //===========================================================
@@ -634,14 +650,14 @@ module hookLidInside()
 // origin = box(0,0,shellHeight)
 module hookLidOutsidePre()
 {
-  if (printMessages) echo("hookLidOutsidePre() ..");
+  //if (printMessages) echo("hookLidOutsidePre() ..");
 } // hookLidOutsidePre()
 
 //===========================================================
 // origin = box(0,0,shellHeight)
 module hookLidOutside()
 {
-  if (printMessages) echo("hookLidOutside() ..");
+  //if (printMessages) echo("hookLidOutside() ..");
 } // hookLidOutside()
 
 //===========================================================
@@ -649,14 +665,14 @@ module hookLidOutside()
 // origin = box(0,0,0)
 module hookBaseInsidePre()
 {
-  if (printMessages) echo("hookBaseInsidePre() ..");
+  //if (printMessages) echo("hookBaseInsidePre() ..");
 } // hookBaseInsidePre()
 
 //===========================================================
 // origin = box(0,0,0)
 module hookBaseInside()
 {
-  if (printMessages) echo("hookBaseInside() ..");
+  //if (printMessages) echo("hookBaseInside() ..");
 } // hookBaseInside()
 
 //===========================================================
@@ -664,14 +680,14 @@ module hookBaseInside()
 // origin = box(0,0,0)
 module hookBaseOutsidePre()
 {
-  if (printMessages) echo("hookBaseOutsidePre() ..");
+  //if (printMessages) echo("hookBaseOutsidePre() ..");
 } // hookBaseOutsidePre()
 
 //===========================================================
 // origin = box(0,0,0)
 module hookBaseOutside()
 {
-  if (printMessages) echo("hookBaseOutside() ..");
+  //if (printMessages) echo("hookBaseOutside() ..");
 } // hookBaseOutside()
 
 //===========================================================
@@ -1966,7 +1982,9 @@ module processCutoutList_Face(face, cutoutList, casePart, swapXY, swapWH, invert
     theDepth = getParamWithDefault(cutOut[6],0);
     theAngle = getParamWithDefault(cutOut[7],0);
 
-    usePCBCoordinates = isTrue(yappCoordPCB, cutOut);
+    // Calculate based on the Coordinate system (test for Box override) thus defaulting to PCB
+    usePCBCoordinates = isTrue(yappCoordBox, cutOut) ? false : true ;
+//    usePCBCoordinates = isTrue(yappCoordPCB, cutOut);
     useCenterCoordinates = isTrue(yappCenter, cutOut);
     
     originLLOpt = isTrue(yappLeftOrigin, cutOut);
@@ -2005,20 +2023,28 @@ module processRidgeExtList_Face(face, ridgeExtList, casePart, swapXY, swapWH, in
 {
   for ( ridgeExt = ridgeExtList )
   {
+    // Calculate based on the Coordinate system (test for Box override) thus defaulting to PCB
+    usePCBCoordinates = isTrue(yappCoordBox, ridgeExt) ? false : true ;
+    
+    // Convert x pos if needed
+    thexTemp = (usePCBCoordinates) ? translatePCB2Box_X(ridgeExt[0], face) : ridgeExt[0];
+     
     // add slack for the part connected to the lid
     useCenterCoordinates = isTrue(yappCenter, ridgeExt); 
-    theX = (subtract) ? ridgeExt[0] : ridgeExt[0] + ridgeSlack;
     
+    theX = (subtract) ? thexTemp : thexTemp + ridgeSlack;
     theY =  baseWallHeight+basePlaneThickness;// RidgePos
-    
     theWidth = ridgeExt[1];
-    theLength = ridgeExt[2];
+    //theLength = ridgeExt[2];
+    theLength = (usePCBCoordinates) ? translatePCB2Box_Y(ridgeExt[2], face) : ridgeExt[2];
      
     originLLOpt = isTrue(yappLeftOrigin, ridgeExt);
     
     // Calc H&W if only Radius is given
     tempWidth = (subtract) ? theWidth : theWidth - ridgeSlack*2;
-    tempLength = theLength;
+    
+    // Shift so that 0 aligns with the original seam
+    tempLength = theY - theLength;
     
     base_width  = (swapWH) ? tempLength : tempWidth;
     base_height = (swapWH) ? tempWidth : tempLength;
@@ -2599,10 +2625,11 @@ module buildButtons()
                 if (!isTrue(yappNoFillet, button))
                 {
                   filletRadius = (filletRad==0) ? lidPlaneThickness : filletRad; 
+                  filletRadiusTrimmed = (filletRadius > cupDepth) ? cupDepth : filletRadius;
                   translate([(cLength+buttonSlack+buttonWall)/2,
                     (cLength+buttonSlack+buttonWall)/2,
                     cupDepth-lidPlaneThickness])
-                  color("violet") pinFillet(-(cLength+buttonSlack+buttonWall)/2,filletRadius);
+                  color("violet") pinFillet(-(cLength+buttonSlack+buttonWall)/2,filletRadiusTrimmed);
                 } // ifFillet
               }
               //-------- outside pole holder
@@ -2611,9 +2638,12 @@ module buildButtons()
                 color("gray") cylinder(h=poleHolderLength, d=pDiam+buttonSlack+buttonWall);
                 if (!isTrue(yappNoFillet, button))
                 {
-                  filletRadius = (filletRad==0) ? lidPlaneThickness : filletRad; 
-                  translate([0, 0, poleHolderLength - cupDepth + buttonWall/2])
-                  color("violet") pinFillet(-(pDiam+buttonSlack+buttonWall)/2,filletRadius);
+                  holderHeight = poleHolderLength - cupDepth + buttonWall/2;
+                  filletRadius = (filletRad==0) ? lidPlaneThickness : filletRad;
+                  // Limit the fillet to the height of the pole 
+                  filletRadiusTrimmed = (filletRadius > holderHeight) ? (holderHeight > 0) ? holderHeight : 0 : filletRadius;
+                  translate([0, 0, holderHeight])
+                  color("violet") pinFillet(-(pDiam+buttonSlack+buttonWall)/2,filletRadiusTrimmed);
                 } // ifFillet
               }
             } //-- union()
@@ -2920,7 +2950,6 @@ module baseShell()
   //echo("base:", posZ00=posZ00);
   translate([(shellLength/2), shellWidth/2, posZ00])
   {
- //qqqqq
     difference()  //(b) Remove the yappLid from the base
     {
       // Create the shell and add the Mounts and Hooks
@@ -3712,6 +3741,13 @@ module drawLid() {
     
   } //  difference(t1)
   
+  // Do the post cutout hook
+  posZ00 = lidWallHeight+lidPlaneThickness;
+  translate([(shellLength/2), (shellWidth/2), (posZ00*-1)])
+  {
+    minkowskiBox(yappLid, shellInsideLength,shellInsideWidth, lidWallHeight, roundRadius, lidPlaneThickness, wallThickness, false);
+  }
+  
   // Add the text
   translate([shellLength-15, -15, 0])
     linear_extrude(1) 
@@ -4229,6 +4265,76 @@ function getVectorInVector(identifier, setArray) =
   ( setArray[18][0][0] == identifier) ? setArray[18] : 
   ( setArray[19][0][0] == identifier) ? setArray[19] : false ;
   
+function translatePCB2Box_X (value, face) =
+  (face==yappLeft)   ? value + pcbX :
+  (face==yappRight)  ? value + pcbX :
+  (face==yappFront)  ? value + pcbY :
+  (face==yappBack)   ? value + pcbY :
+  (face==yappTop)    ? value + pcbX :
+  (face==yappBottom) ? value + pcbX : undef;
+  
+function translatePCB2Box_Y (value, face) =
+  (face==yappLeft)   ? value + pcbZ :
+  (face==yappRight)  ? value + pcbZ :
+  (face==yappFront)  ? value + pcbZ :
+  (face==yappBack)   ? value + pcbZ :
+  (face==yappTop)    ? value + pcbY :
+  (face==yappBottom) ? value + pcbY : undef;
+  
+function translatePCB2Box_Z (value, face) =
+  (face==yappLeft)   ? value + pcbY :
+  (face==yappRight)  ? value + pcbY :
+  (face==yappFront)  ? value + pcbX :
+  (face==yappBack)   ? value + pcbX :
+  (face==yappTop)    ? value + pcbZ :
+  (face==yappBottom) ? value + pcbZ : undef;
+  
+function translateX2LeftOrigin (value, face) =
+  (face==yappLeft)   ? value :
+  (face==yappRight)  ? shellLength - value :
+  (face==yappFront)  ? value :
+  (face==yappBack)   ? shellWidth - value :
+  (face==yappTop)    ? shellHeight - value :
+  (face==yappBottom) ? value : undef;
+
+  
+  
+module TestCoordTranslations()
+{
+  module TestPCB2Box(x,y,z, face)
+  {
+    X = translatePCB2Box_X (x, face);
+    Y = translatePCB2Box_Y (y, face);
+    Z = translatePCB2Box_Z (z, face);
+    echo (str(getPartName(face), " PCB to Box Coord [" , x, ", ", y, ", ", z, "] -> [" , X, ", ", Y, ", ", Z, "]"));
+  }
+  module TestX2LeftOrigin(x, face)
+  {
+    X = translateX2LeftOrigin (x, face);
+    echo (str(getPartName(face), " X to LeftOrigin [" , x, "] -> [" , X, "]"));
+  }
+  
+  TestPCB2Box(0,0,0, yappLeft);
+  TestPCB2Box(0,0,0, yappRight);
+  TestPCB2Box(0,0,0, yappFront);
+  TestPCB2Box(0,0,0, yappBack);
+  TestPCB2Box(0,0,0, yappTop);
+  TestPCB2Box(0,0,0, yappBottom);
+
+  TestX2LeftOrigin(0, yappLeft);
+  TestX2LeftOrigin(10, yappLeft);
+  TestX2LeftOrigin(0, yappRight);
+  TestX2LeftOrigin(10, yappRight);
+  TestX2LeftOrigin(0, yappFront);
+  TestX2LeftOrigin(10, yappFront);
+  TestX2LeftOrigin(0, yappBack);
+  TestX2LeftOrigin(10, yappTop);
+  TestX2LeftOrigin(0, yappTop);
+  TestX2LeftOrigin(10, yappBottom);
+  TestX2LeftOrigin(0, yappBottom);
+ 
+} //TestCoordTranslations
+  
 module genMaskfromList(theList, width, height, depth)
 {
   if (debug)
@@ -4262,7 +4368,9 @@ module SamplePolygon(thePolygon)
   }
 } // SamplePolygon
 
+// -- Sample test calls --
 //SamplePolygon( shape6ptStar);
+//TestCoordTranslations();
 
 // End of test modules 
   


### PR DESCRIPTION
also added using the 2 coordinate systems in the Ridge Extensions.  Since it was at an odd reference before (the outside of the shell for horizontal and the ridge height for the vertical origin I changed how it works.

So now if you have PCB coordinates it starts at the edge of the PCB horizontally and the top of the PCB vertically with negative being below the PCB.  In Box it goes from the origin with only positive heights.