### PR TITLE
Connector default Coordinate system fix.

### DIFF
--- a/YAPP_connectors_v30.scad
+++ b/YAPP_connectors_v30.scad
@@ -71,7 +71,7 @@ inspectZfromBottom        = true;       //-> View from the inspection cut up
 //  *** Connectors ***
 //  Standoffs with hole through base and socket in lid for screw type connections.
 //-------------------------------------------------------------------
-//  Default origin = yappCoordBox: box[0,0,0]
+//  Default origin = yappCoordPCB: pcb[0,0,0]
 //  
 //  Parameters:
 //   Required:
@@ -92,11 +92,11 @@ inspectZfromBottom        = true;       //-> View from the inspection cut up
 //-------------------------------------------------------------------
 connectors   =
 [
-  [ 10, 10, 4, 3, 5, 4, 7, yappAllCorners, yappCoordPCB] // All of the corners of the PCB inset 10,10
- ,[ 8, 8, 4, 3, 5, 4, 7] //Defaults to yappBackLeft of yappCoordBox
+  [ 10, 10, 4, 3, 5, 4, 7, yappAllCorners] // All of the corners of the PCB inset 10,10
+ ,[ 8, 8, 4, 3, 5, 4, 7, yappCoordBox] //Defaults to yappBackLeft of yappCoordBox
  ,[ 8-wallThickness, 28, 4, 3, 5, 4, 7, 5, 1.6, yappBackLeft, yappCoordBoxInside] // Shifted so that they all aligh for inspection cut
- ,[ 8-pcbX, 48, 4, 3, 5, 4, 7, 16, yappBackLeft, yappCoordPCB] // Shifted so that they all aligh for inspection cut
- ,[ 8, 68, 14, 3, 5, 4, 7, 6, yappBackLeft] // Shifted so that they all aligh for inspection cut
+ ,[ 8-pcbX, 48, 4, 3, 5, 4, 7, 16, yappBackLeft] // Shifted so that they all aligh for inspection cut
+ ,[ 8, 68, 14, 3, 5, 4, 7, 6, yappBackLeft, yappCoordBox] // Shifted so that they all aligh for inspection cut
 ];
 
 //---- This is where the magic happens ----

--- a/library/YAPPgenerator_v30.scad
+++ b/library/YAPPgenerator_v30.scad
@@ -418,7 +418,7 @@ pcbStands =
 //  *** Connectors ***
 //  Standoffs with hole through base and socket in lid for screw type connections.
 //-------------------------------------------------------------------
-//  Default origin = yappCoordBox: box[0,0,0]
+//  Default origin =  yappCoordPCB : pcb[0,0,0]
 //  
 //  Parameters:
 //   Required:
@@ -434,7 +434,7 @@ pcbStands =
 //    p(8) = PCB Gap : Default if yappCoordPCB then pcbThickness else 0
 //    p(9) = filletRadius : Default = 0/Auto(0 = auto size)
 //    n(a) = { yappAllCorners, yappFrontLeft | <yappBackLeft> | yappFrontRight | yappBackRight }
-//    n(b) = { yappCoordPCB | <yappCoordBox> | yappCoordBoxInside }
+//    n(b) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside }
 //    n(c) = { yappNoFillet }
 //-------------------------------------------------------------------
 connectors   =
@@ -447,7 +447,7 @@ connectors   =
 //    There are 6 cutouts one for each surface:
 //      cutoutsBase (Bottom), cutoutsLid (Top), cutoutsFront, cutoutsBack, cutoutsLeft, cutoutsRight
 //-------------------------------------------------------------------
-//  Default origin = yappCoordBox: box[0,0,0]
+//  Default origin =  yappCoordPCB : pcb[0,0,0]
 //
 //                        Required                Not Used        Note
 //----------------------+-----------------------+---------------+------------------------------------
@@ -2278,7 +2278,7 @@ module cutoutsForScrewHoles(type)
     primeOrigin = (!isTrue(yappBackLeft, conn) && !isTrue(yappFrontLeft, conn) && !isTrue(yappFrontRight, conn) && !isTrue(yappBackRight, conn) && !isTrue(yappAllCorners, conn) ) ? true : false;
         
     // Get the desired coordinate system    
-    theCoordSystem = getCoordSystem(conn, yappCoordBox);    
+    theCoordSystem = getCoordSystem(conn, yappCoordPCB);    
     face = (type==yappPartBase) ? yappBase : undef ;
  
     theLength = getLength(theCoordSystem);
@@ -3329,7 +3329,7 @@ module shellConnectors(shellPart)
     primeOrigin = (!isTrue(yappBackLeft, conn) && !isTrue(yappFrontLeft, conn) && !isTrue(yappFrontRight, conn) && !isTrue(yappBackRight, conn) && !isTrue(yappAllCorners, conn) ) ? true : false;
     
     // Get the desired coordinate system    
-    theCoordSystem = getCoordSystem(conn, yappCoordBox);    
+    theCoordSystem = getCoordSystem(conn, yappCoordPCB);    
     face = (shellPart==yappPartBase) ? yappBase : yappLid ;
  
     theLength = getLength(theCoordSystem);


### PR DESCRIPTION
Not sure if I did it during my testing or when it was merged. But the default coordinate systems seem to be out of sync.
//===================================================================
// *** PCB Supports ***
...
//  Default origin =  yappCoordPCB : pcb[0,0,0]
...
//    n(d) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside }
pcbStands yappCoordPCB is the default 
So that one is all good.

//===================================================================
//  *** Connectors ***
//  Standoffs with hole through base and socket in lid for screw type connections.
//-------------------------------------------------------------------
//  Default origin = yappCoordBox: box[0,0,0]
...
//    n(b) = { yappCoordPCB | <yappCoordBox> | yappCoordBoxInside }
and the default is yappCoordBox so it all matches.

**But I thought you wanted it to be yappCoordPCB.** So I changed it to PCB coordinates.

//===================================================================
//  *** Cutouts ***
//  Default origin = **yappCoordBox**: box[0,0,0]
...
//    n(d) = { <**yappCoordPCB**> | yappCoordBox | yappCoordBoxInside }

the default is yappCoordPCB.

So the first part of the description was wrong. I corrected that.  
