### PR TITLE
Fix missplaced text label in base plane

### DIFF
--- a/library/YAPPgenerator_v30.scad
+++ b/library/YAPPgenerator_v30.scad
@@ -2768,7 +2768,7 @@ module drawLabels(casePart, subtract)
         if (printMessages) echo ("Draw text on Base (bottom)");
         offset_depth = (subtract) ?  -0.01 : -theDepth + 0.01;
         
-        translate([label[0], shellWidth-label[0], offset_depth]) 
+        translate([label[0], shellWidth-label[1], offset_depth]) 
         {
           rotate([0,0,180-label[2]])
           {


### PR DESCRIPTION
There's a typo in drawLabels() in the base plane for Y axis.