### PR TITLE
Multi PCB option

### DIFF
--- a/YAPPgenerator_v3.scad
+++ b/YAPPgenerator_v3.scad
@@ -4,7 +4,7 @@
 **
 */
 
-Version="v3.0.0 (16-12-2023)";
+Version="v3.0.1 (2024-01-17)";
 /*
 **
 **  Copyright (c) 2021, 2022, 2023, 2024 Willem Aandewiel
@@ -114,7 +114,7 @@ standoffHoleSlack   = 0.4;
 
 pcb = 
 [
-  // Default Main PCB - DO NOT REMOVE the "Main" line.
+  //-- Default Main PCB - DO NOT REMOVE the "Main" line.
   ["Main",              pcbLength,pcbWidth,    0,0,    pcbThickness,  standoffHeight, standoffDiameter, standoffPinDiameter, standoffHoleSlack]
 ];
 
@@ -232,7 +232,7 @@ yappBase                = -30305;
 yappPartBase            = -30306;
 yappPartLid             = -30307;
 
-// Placement Options
+//-- Placement Options
 yappCenter              = -30400;  // Cutouts, boxMounts, lightTubes, pushButtons, pcbStands, Connectors
 yappOrigin              = -30401;  // Cutouts, boxMounts, lightTubes, pushButtons, pcbStands, Connectors
 
@@ -422,7 +422,7 @@ preDefinedMasks=[
 
 
 
-// Show sample of a Mask.in the negative X,Y quadrant
+//-- Show sample of a Mask.in the negative X,Y quadrant
 //SampleMask(maskHoneycomb);
 
 //===================================================================
@@ -721,126 +721,89 @@ ridgeExtRight =
 
 
 //========= HOOK functions ============================
-  
-// Hook functions allow you to add 3d objects to the case.
-// Lid/Base = Shell part to attach the object to.
-// Inside/Outside = Join the object from the midpoint of the shell to the inside/outside.
-// Pre = Attach the object Pre before doing Cutouts/Stands/Connectors. 
-
+//-- Hook functions allow you to add 3d objects to the case.
+//-- Lid/Base = Shell part to attach the object to.
+//-- Inside/Outside = Join the object from the midpoint of the shell to the inside/outside.
+//-- Pre = Attach the object Pre before doing Cutouts/Stands/Connectors. 
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookLidInsidePre()
 {
   //if (printMessages) echo("hookLidInsidePre() ..");
   
-} // hookLidInsidePre()
+} //-- hookLidInsidePre()
 
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookLidInside()
 {
   //if (printMessages) echo("hookLidInside() ..");
   
-} // hookLidInside()
+} //-- hookLidInside()
   
 //===========================================================
 //===========================================================
-// origin = box(0,0,shellHeight)
+//-- origin = box(0,0,shellHeight)
 module hookLidOutsidePre()
 {
   //if (printMessages) echo("hookLidOutsidePre() ..");
   
-} // hookLidOutsidePre()
+} //-- hookLidOutsidePre()
 
 //===========================================================
-// origin = box(0,0,shellHeight)
+//-- origin = box(0,0,shellHeight)
 module hookLidOutside()
 {
   //if (printMessages) echo("hookLidOutside() ..");
   
-} // hookLidOutside()
+} //-- hookLidOutside()
 
 //===========================================================
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookBaseInsidePre()
 {
   //if (printMessages) echo("hookBaseInsidePre() ..");
   
-} // hookBaseInsidePre()
+} //-- hookBaseInsidePre()
 
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookBaseInside()
 {
   //if (printMessages) echo("hookBaseInside() ..");
   
-} // hookBaseInside()
+} //-- hookBaseInside()
 
 //===========================================================
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookBaseOutsidePre()
 {
   //if (printMessages) echo("hookBaseOutsidePre() ..");
   
-} // hookBaseOutsidePre()
+} //-- hookBaseOutsidePre()
 
 //===========================================================
-// origin = box(0,0,0)
+//-- origin = box(0,0,0)
 module hookBaseOutside()
 {
   //if (printMessages) echo("hookBaseOutside() ..");
   
-} // hookBaseOutside()
+} //-- hookBaseOutside()
 
 //===========================================================
 //===========================================================
 
-// **********************************************************
-// **********************************************************
-// **********************************************************
-// *************** END OF TEMPLATE SECTION ******************
-// **********************************************************
-// **********************************************************
-// **********************************************************
+//-- **********************************************************
+//-- **********************************************************
+//-- **********************************************************
+//-- *************** END OF TEMPLATE SECTION ******************
+//-- **********************************************************
+//-- **********************************************************
+//-- **********************************************************
 
 
-
-//===========================================================
-// General functions
-//===========================================================
-//===========================================================
-//function getMinRad(p1, wall) = ((p1<(wall+0.001)) ? 1 : (p1 - wall));
-
-function getMinRad(p1, wall) = ((p1<(wall)) ? 1 : (p1 - wall));
-// Check the first 21 elements in an array (I don't think any will be over 21)
-function isTrue(constantValue, setArray) = (
-  (   setArray[0] == constantValue 
-   || setArray[1] == constantValue 
-   || setArray[2] == constantValue 
-   || setArray[3] == constantValue 
-   || setArray[4] == constantValue 
-   || setArray[5] == constantValue 
-   || setArray[6] == constantValue 
-   || setArray[7] == constantValue 
-   || setArray[8] == constantValue 
-   || setArray[9] == constantValue 
-   || setArray[10] == constantValue 
-   || setArray[11] == constantValue 
-   || setArray[12] == constantValue 
-   || setArray[13] == constantValue 
-   || setArray[14] == constantValue 
-   || setArray[15] == constantValue 
-   || setArray[16] == constantValue 
-   || setArray[17] == constantValue 
-   || setArray[18] == constantValue 
-   || setArray[19] == constantValue ) ? 1 : 0);  
-   
-//===========================================================
- 
-function minOutside(ins, outs) = ((((ins*1.5)+0.2)>=outs) ? (ins*1.5)+0.2 : outs);  
-function countersinkHeight(conn) = (conn[4] / 2) / tan (countersinkAngle / 2);
 
 //===========================================================
 module printBoxMounts()
@@ -854,38 +817,35 @@ module printBoxMounts()
         l  = size[3];
         h  = size[4];
       
-        //if (l>radius)
+        linear_extrude(h)
         {
-          linear_extrude(h)
+          hull()
           {
-            hull()
-            {
-              // place 4 circles in the corners, with the given radius
-              translate([(x1+radius), (y+radius), 0])
-                circle(r=radius);
-            
-              translate([(x1+radius), (y+l)+radius, 0])
-                circle(r=radius);
-            
-              translate([(x2+radius), (y+l)+radius, 0])
-                circle(r=radius);
-            
-              translate([(x2+radius), (y+radius), 0])
-                circle(r=radius);
-            }
-          } // extrude..
-        } //  translate      
-      } // roundRect()
+            // place 4 circles in the corners, with the given radius
+            translate([(x1+radius), (y+radius), 0])
+              circle(r=radius);
+          
+            translate([(x1+radius), (y+l)+radius, 0])
+              circle(r=radius);
+          
+            translate([(x2+radius), (y+l)+radius, 0])
+              circle(r=radius);
+          
+            translate([(x2+radius), (y+radius), 0])
+              circle(r=radius);
+          }
+        } // linear_extrude
+      } //-- roundRect()
       //-------------------------------------------------------------------
   
       module oneMount(bm, maxLength, originLLOpt, invertX)
       {
         isCenter = isTrue(yappCenter, bm);
-        mountPosRaw1 = is_list(bm[0]) ? bm[0][0] : bm[0]; // = posx
-        mountOpeningDiameter = bm[1];                     // = screwDiameter
-        mountWidthRaw = bm[2];                            // = width
-        mountHeight = bm[3];                              // = Height
-        filletRad = getParamWithDefault(bm[4],0);         // fillet radius
+        mountPosRaw1 = is_list(bm[0]) ? bm[0][0] : bm[0]; //-- = posx
+        mountOpeningDiameter = bm[1];                     //-- = screwDiameter
+        mountWidthRaw = bm[2];                            //-- = width
+        mountHeight = bm[3];                              //-- = Height
+        filletRad = getParamWithDefault(bm[4],0);         //-- fillet radius
         bmYpos    = is_list(bm[0]) 
                   ? (mountOpeningDiameter*-2) - bm[0][1] 
                   : (mountOpeningDiameter*-2);   
@@ -894,11 +854,11 @@ module printBoxMounts()
         mountWidth = slotOrientation ? mountWidthRaw : 0;
         mountLength = slotOrientation ? 0 : mountWidthRaw;
         
-        // Adjust for centered mounts
+        //-- Adjust for centered mounts
         mountPosRaw2 = (isCenter) ? mountPosRaw1 - (mountWidth/2) : mountPosRaw1;
-        // Adjust for inverted axis
+        //-- Adjust for inverted axis
         mountPosRaw = invertX ? mountPosRaw2 : -mountPosRaw2;
-        // Adjust for LowerLeft Origin
+        //-- Adjust for LowerLeft Origin
         mountPos = originLLOpt ? maxLength - mountPosRaw - mountWidth : mountPosRaw;
      
         totalmountWidth = mountWidth+mountOpeningDiameter*2;
@@ -913,14 +873,14 @@ module printBoxMounts()
     
         filletRadius = (filletRad==0) ? mountHeight/4 : filletRad;
         
-        outRadius = mountOpeningDiameter;  // rad := diameter (r=6 := d=6)
+        outRadius = mountOpeningDiameter;
         bmX1pos   = scrwX1pos-mountOpeningDiameter;
         bmX2pos   = scrwX2pos-outRadius;
             
         bmYpos1   = (slotOrientation) ? bmYpos : bmYpos + newLength;
         bmLen     = -bmYpos1+roundRadius;
             
-        // Get where to connect the mount defaulting to base
+        //-- Get where to connect the mount defaulting to base
         mountToPart = (isTrue(yappLid, bm)) ? yappLid : yappBase; 
         
         mountOffsetZ = (mountToPart==yappBase) ? 0 : -shellHeight + (mountHeight*2);
@@ -932,34 +892,34 @@ module printBoxMounts()
           {
             difference()
             {
-              // Mounting tab
+              //-- Mounting tab
               color("red")
               roundedRect([bmX1pos,bmX2pos,bmYpos1,bmLen,mountHeight], outRadius);
               translate([0, (bmYpos + mountOpeningDiameter), -1])
               {
-                // Slot
+                //-- Slot
                 color("blue")
                 hull() 
                 {
                   linear_extrude(mountHeight*2)
                   {
-                  //  translate([scrwX1pos - mountPos,0, 0]) 
+                  // translate([scrwX1pos - mountPos,0, 0]) 
                     translate([scrwX1pos,scrwY1pos, 0]) 
                       color("blue")
                       {
                         circle(mountOpeningDiameter/2);
                       }
-                  //  translate([scrwX2pos - mountPos, 0, 0]) 
+                  // translate([scrwX2pos - mountPos, 0, 0]) 
                     translate([scrwX2pos, scrwY2pos, 0]) 
                       color("blue")
                         circle(mountOpeningDiameter/2);
-                  } //  extrude
+                  } // extrude
                 } // hull
-              } //  translate
+              } // translate
             
             } // difference..
             
-            // add fillet
+            //-- add fillet
             if (!isTrue(yappNoFillet, bm))
             {
               filletRad = min(filletRadius, -bmYpos/4);
@@ -978,7 +938,7 @@ module printBoxMounts()
             } // Fillet
           } // difference
         } //mirror
-      } //  oneMount()
+      } //-- oneMount()
       
     //--------------------------------------------------------------------
     function maxWidth(w, r, l) = (w>(l-(r*4)))        ? l-(r*4)      : w;
@@ -1039,16 +999,11 @@ module printBoxMounts()
           }
         } //  if yappBack
       } // for ..
-      
   } //  translate to [0,0,0]
-    
-} //  printBoxMounts()
+} //-- printBoxMounts()
 
 
 //===========================================================
-// Change to one module for both parts yappPartBase and yappPartLid
-
-//module printBaseSnapJoins()
 module printSnapJoins(casePart)
 {
   if (casePart == yappPartBase) 
@@ -1168,7 +1123,7 @@ module printSnapJoins(casePart)
       }
       else 
       {
-        // Use Diamond shaped snaps
+        //-- Use Diamond shaped snaps
         
         if (isTrue(yappLeft, snj))
         {
@@ -1265,16 +1220,14 @@ module printSnapJoins(casePart)
           } // yappCenter
         } // yappFront
       } // diamondshape
-     
     } // for snj .. 
   } //  Base
 
   if (casePart == yappPartLid) 
   {
-    // The cutout/reciever 
+    //-- The cutout/reciever 
     if (len(snapJoins) > 0) 
     {
-      //echo (ridgeHeight=ridgeHeight,wallThickness=wallThickness);
       assert ((ridgeHeight >= (wallThickness*1.8)), "ridgeHeight < 1.8 times wallThickness: no SnapJoins possible");
     }
     
@@ -1309,7 +1262,6 @@ module printSnapJoins(casePart)
             {
               color("blue") cube([snapWidth, wallThickness+0.04, snapDiam]);
             }
-            
           } // yappSymmetric
         } // yappLeft
         
@@ -1324,8 +1276,7 @@ module printSnapJoins(casePart)
             translate([shellLength-(snapApos+(snapWidth/2)), shellWidth-wallThickness-0.02, snapZpos])
             {
               color("blue") cube([snapWidth, wallThickness+0.04, snapDiam]);
-            }
-            
+            } 
           } // yappSymmetric
         } // yappRight
         
@@ -1341,7 +1292,6 @@ module printSnapJoins(casePart)
             {
               color("blue") cube([wallThickness+0.04, snapWidth, snapDiam]);
             }
-            
           } // yappSymmetric
         } // yappBack
         
@@ -1357,7 +1307,6 @@ module printSnapJoins(casePart)
             {
               color("blue") cube([wallThickness+0.04, snapWidth, snapDiam]);
             }
-            
           } // yappSymmetric
         } // yappFront
       }
@@ -1381,7 +1330,6 @@ module printSnapJoins(casePart)
                 rotate([45,0,0])
               color("blue") cube([snapWidth+1, snapDiam, snapDiam]);
             }
-            
           } // yappSymmetric
         } // yappLeft
         
@@ -1400,8 +1348,7 @@ module printSnapJoins(casePart)
               scale([1,.60, 1])
                 rotate([45,0,0])
               color("blue") cube([snapWidth+1, snapDiam, snapDiam]);
-            }
-            
+            } 
           } // yappSymmetric
         } // yappRight
         
@@ -1448,7 +1395,7 @@ module printSnapJoins(casePart)
       }
     } // for snj .. 
   } //  Lid()
-} //printSnapJoins()
+} //-- printSnapJoins()
 
 //===========================================================
 module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
@@ -1466,7 +1413,7 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       sphere(rad*minkowskiErrorCorrection); // Compensate for minkowski error
     }
 
-  }
+  } //-- minkowskiOuterBox()
 
   module minkowskiCutBox(L, W, H, rad, plane, wall)
   {
@@ -1476,7 +1423,8 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       sphere(rad*minkowskiErrorCorrection);
     }
 
-  }
+  } //-- minkowskiCutBox()
+  
   //--------------------------------------------------------
   module minkowskiInnerBox(L, W, H, iRad, plane, wall)
   {
@@ -1485,11 +1433,8 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       cube([L-((iRad*2)), W-((iRad*2)), (H*2)-((iRad*2))], center=true);
       sphere(iRad*minkowskiErrorCorrection); // Compensate for minkowski error
     }
-  }
+  } //-- minkowskiInnerBox()
   //--------------------------------------------------------
-  
-  //echo("Box:", L=L, W=W, H=H, rad=rad, iRad=iRad, wall=wall, plane=plane);
-  //echo("Box:", L2=L-(rad*2), W2=W-(rad*2), H2=H-(rad*2), rad=rad, wall=wall);
   
   if (preCutouts) 
   {
@@ -1504,17 +1449,17 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
         } // difference()
       } // if (len(boxMounts) > 0)
      
-      // Objects to be cut to outside the box       
+      //-- Objects to be cut to outside the box       
       color("Orange")
       difference()
       {
-        // move it to the origin of the base
+        //-- move it to the origin of the base
         translate ([-L/2, -W/2, -H]) // -baseWallHeight])
           hookBaseOutsidePre();    
         minkowskiCutBox(L, W, H, cRad, plane, wall);
       } // difference()
     
-      //draw stuff inside the box
+      //-- draw stuff inside the box
       color("LightBlue")
       intersection()
       {
@@ -1523,8 +1468,7 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
           hookBaseInsidePre();
       } // intersection()
 
-
-      // The actual box
+      //-- The actual box
       color(colorBase, alphaBase)
       difference()
       {
@@ -1532,13 +1476,13 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
         minkowskiInnerBox(L, W, H, iRad, plane, wall);
       } // difference
    
-      // Draw the labels that are added (raised) from the case
+      //-- Draw the labels that are added (raised) from the case
       color("DarkGreen") drawLabels(yappPartBase, false);
 
     } // if (shell==yappPartBase)
     else
     {
-      //Lid
+      //-- Lid
       if (len(boxMounts) > 0)
       {
         difference()
@@ -1552,14 +1496,14 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       color("Red")
       difference()
       {
-        // Objects to be cut to outside the box 
-        // move it to the origin of the base
+        //-- Objects to be cut to outside the box 
+        //-- move it to the origin of the base
         translate ([-L/2, -W/2, H]) //lidWallHeight])
         hookLidOutsidePre();
         minkowskiCutBox(L, W, H, cRad, plane, wall);
       } // difference()
       
-      //draw stuff inside the box
+      //-- draw stuff inside the box
       color("LightGreen")
       intersection()
       {
@@ -1568,7 +1512,7 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
           hookLidInsidePre();
       } //intersection()
 
-      // The actual box
+      //-- The actual box
       color(colorLid, alphaLid)
       difference()
       {
@@ -1576,15 +1520,14 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
         minkowskiInnerBox(L, W, H, iRad, plane, wall);
       } // difference  
 
-
-      // Draw the labels that are added (raised) from the case
+      //-- Draw the labels that are added (raised) from the case
       color("DarkGreen") drawLabels(yappPartLid, false);
 
     }
   }
   else // preCutouts
   {
-    // Only add the Post hooks
+    //-- Only add the Post hooks
     if (shell==yappPartBase)
     {
       color("Orange")
@@ -1612,14 +1555,14 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       color("Red")
       difference()
       {
-        // Objects to be cut to outside the box 
-        // move it to the origin of the base
+        //-- Objects to be cut to outside the box 
+        //-- move it to the origin of the base
         translate ([-L/2, -W/2, H])
         hookLidOutside();
         minkowskiCutBox(L, W, H, cRad, plane, wall);
       } // difference()
 
-      //draw stuff inside the box
+      //-- draw stuff inside the box
       color("LightGreen")
       intersection()
       {
@@ -1629,15 +1572,15 @@ module minkowskiBox(shell, L, W, H, rad, plane, wall, preCutouts)
       }
     }
   } //preCutouts
-} //  minkowskiBox()
+} //-- minkowskiBox()
 
 
 //===========================================================
 module showPCBMarkers(thePCB)
 {  
-  pcb_Length     = pcbLength(thePCB[0]); //thePCB[1];
-  pcb_Width      = pcbWidth(thePCB[0]); //thePCB[2];
-  pcb_Thickness  = pcbThickness(thePCB[0]); //thePCB[5];
+  pcb_Length     = pcbLength(thePCB[0]); 
+  pcb_Width      = pcbWidth(thePCB[0]); 
+  pcb_Thickness  = pcbThickness(thePCB[0]); 
 
   posX          = translate2Box_X(0, yappBase, [yappCoordPCB, yappGlobalOrigin, thePCB[0]]);
   posY          = translate2Box_Y(0, yappBase, [yappCoordPCB, yappGlobalOrigin, thePCB[0]]);
@@ -1645,30 +1588,29 @@ module showPCBMarkers(thePCB)
 
   {
     markerHeight=shellHeight+onLidGap+10;
-    //echo("Markers:", markerHeight=markerHeight);
-    // Back Left 
-    translate([0, 0, (markerHeight/2) -posZ - 5]) //basePlaneThickness+(onLidGap/2)])
+    //-- Back Left 
+    translate([0, 0, (markerHeight/2) -posZ - 5]) 
       color("red",0.50)
         %cylinder(
           r = .5,
           h = markerHeight,
           center = true);
 
-    translate([0, pcb_Width, (markerHeight/2) -posZ - 5]) //basePlaneThickness+(onLidGap/2)])
+    translate([0, pcb_Width, (markerHeight/2) -posZ - 5]) 
       color("red",0.50)
         %cylinder(
           r = .5,
           h = markerHeight,
           center = true);
 
-    translate([pcb_Length, pcb_Width, (markerHeight/2) -posZ - 5]) //basePlaneThickness+(onLidGap/2)])
+    translate([pcb_Length, pcb_Width, (markerHeight/2) -posZ - 5]) 
       color("red",0.50)
         %cylinder(
           r = .5,
           h = markerHeight,
           center = true);
 
-    translate([pcb_Length, 0, (markerHeight/2) -posZ - 5]) //basePlaneThickness+(onLidGap/2)])
+    translate([pcb_Length, 0, (markerHeight/2) -posZ - 5]) 
       color("red",0.50)
         %cylinder(
           r = .5,
@@ -1691,7 +1633,6 @@ module showPCBMarkers(thePCB)
             h = shellLength+(wallThickness*2)+paddingBack,
             center = true);
 
-    // add the last 2 markers   
     translate([0, (shellWidth/2)-posY, pcb_Thickness])
       rotate([90,90,0])
         color("red",0.50)
@@ -1709,7 +1650,7 @@ module showPCBMarkers(thePCB)
             center = true);
             
   } // show_markers   
-} //  showMarkersPCB()
+} //-- showMarkersPCB()
 
 
 //===========================================================
@@ -1722,12 +1663,12 @@ module printPCB(thePCB) //posX, posY, posZ, length, width, thickness)
   translate([posX,posY,posZ])
   
   {
-    // Draw the PCB 
+    //-- Draw the PCB 
     color("red", 0.5)
       cube([thePCB[1], thePCB[2], thePCB[5]]);
   
     hshift = (thePCB[1] > thePCB[2]) ? 0 : 4;
-    //Add the name
+    //-- Add the name
     linear_extrude(thePCB[5]+ 0.04) 
     {
       translate([2+hshift,3,0])
@@ -1749,27 +1690,27 @@ module printPCB(thePCB) //posX, posY, posZ, length, width, thickness)
       showPCBMarkers(thePCB);
     }
   }
-} // printPCB()
+} //-- printPCB()
 
 
 //===========================================================
-// Place the standoffs and through-PCB pins in the base Box
+//-- Place the standoffs and through-PCB pins in the base Box
 module pcbHolders() 
 {        
   for ( stand = pcbStands )
   {
-    // Get the PCBinfo 
+    //-- Get the PCBinfo 
     thePCBName = getPCBName(yappPCBName, stand);
    
-    pcb_Length = pcbLength(thePCBName); //thePCB[1] + thePCB[3] + wallThickness+paddingBack;
-    pcb_Width = pcbWidth(thePCBName); //thePCB[2] + thePCB[4] + wallThickness+paddingLeft;
+    pcb_Length = pcbLength(thePCBName);
+    pcb_Width = pcbWidth(thePCBName);
     pcb_Thickness = pcbThickness(thePCBName);
     standoff_Height = standoffHeight(thePCBName);
     pcbStandHeight  = getParamWithDefault(stand[2], standoff_Height);
     filletRad = getParamWithDefault(stand[7],0);
     standType = isTrue(yappHole, stand) ? yappHole : yappPin;
 
-    // Calculate based on the Coordinate system
+    //-- Calculate based on the Coordinate system
     coordSystem = getCoordSystem(stand, yappCoordPCB);
     
     
@@ -1811,7 +1752,7 @@ module pcbHolders()
           pcbStandoff(yappPartBase, pcbStandHeight, filletRad, standType, "green", !isTrue(yappNoFillet, stand),stand);
     } //if
   } //for  
-} // pcbHolders()
+} //-- pcbHolders()
 
 
 
@@ -1821,7 +1762,7 @@ module pcbPushdowns()
 {        
  for ( pushdown = pcbStands )
   {
-    // Get the PCBinfo 
+    //-- Get the PCBinfo 
     thePCB = getPCBInfo(yappPCBName, pushdown);
    
     pcb_Length       = pcbLength(thePCB[0]); 
@@ -1829,24 +1770,21 @@ module pcbPushdowns()
     pcb_Thickness    = pcbThickness(thePCB[0]);
     standoff_Height  = standoffHeight(thePCB[0]);
   
-    // Calculate based on the Coordinate system
+    //-- Calculate based on the Coordinate system
     coordSystem = getCoordSystem(pushdown, yappCoordPCB);
 
     offsetX   = translate2Box_X(0, yappBase, coordSystem);
     offsetY   = translate2Box_Y(0, yappBase, coordSystem);
 
-    // Calculate based on the Coordinate system
+    //-- Calculate based on the Coordinate system
     usePCBCoord = (coordSystem[0] == yappCoordPCB) ? true : false;
     
     pcbGapTmp = getParamWithDefault(pushdown[3],-1);
     pcbGap = (pcbGapTmp == -1 ) ? (usePCBCoord) ? pcb_Thickness : 0 : pcbGapTmp;
 
-    //if (printMessages) echo ("pcbPushdowns", pcbGap=pcbGap);
-    
     filletRad = getParamWithDefault(pushdown[7],0);
     
     pcbStandHeightTemp  = getParamWithDefault(pushdown[2], standoff_Height);
-    //if (printMessages) echo(pcbStandHeightTemp=pcbStandHeightTemp);
     
     pcbStandHeight=(baseWallHeight+lidWallHeight)
                      -(pcbStandHeightTemp+pcbGap);
@@ -1886,7 +1824,7 @@ module pcbPushdowns()
       }
     }
   }  
-} // pcbPushdowns()
+} //-- pcbPushdowns()
 
 //===========================================================
 module sanityCheckList(theList, theListName, minCount, shapeParam=undef, validShapes = []) 
@@ -1897,12 +1835,12 @@ module sanityCheckList(theList, theListName, minCount, shapeParam=undef, validSh
     {
       if (len(theList)>0)
       {
-        // Go throught the vector checking each one
+        //-- Go throught the vector checking each one
         for(pos = [0 : len(theList)-1])
         {
           item = theList[pos];
-          // Check that there are at least the minimun elements
-          // Cutouts require 9 elements
+          //-- Check that there are at least the minimun elements
+          //-- Cutouts require 9 elements
           assert((len(item) >= minCount), str(theListName, " item ", pos, " require ", minCount, " parameters at a minimum.") );
             
           if (shapeParam!=undef)
@@ -1922,10 +1860,10 @@ module sanityCheckList(theList, theListName, minCount, shapeParam=undef, validSh
     {
       if (printMessages) echo (theListName, " is not defined");
     }
-  } // sanityCheckCutoutList
+  } //-- sanityCheckCutoutList()
 
 //===========================================================
-// Master module to process the 4 ridge extension for the box faces
+//-- Master module to process the 4 ridge extension for the box faces
 module makeRidgeExt(type, subtract)
 {      
   if (printMessages) echo("***** Process RidgeExt *****");
@@ -1933,37 +1871,37 @@ module makeRidgeExt(type, subtract)
   processFaceList(yappRight,   ridgeExtRight, type, "ridgeExt", subtract);
   processFaceList(yappFront,   ridgeExtFront, type, "ridgeExt", subtract);
   processFaceList(yappBack,    ridgeExtBack, type, "ridgeExt", subtract);
-} //makeRidgeExt()
+} //-- makeRidgeExt()
 
 
 
 //===========================================================
-// Master module to process the 6 vectors for the box faces
+//-- Master module to process the 6 vectors for the box faces
 module makeCutouts(type)
 {      
   if (type==yappPartBase)
   { 
-    // The bottom plane is only on the Base
+    //-- The bottom plane is only on the Base
     processFaceList(yappBase,  cutoutsBase, type, "cutout", true); 
   }
   else
   {
-    // The bottom plane is only on the Lid
+    //-- The bottom plane is only on the Lid
     processFaceList(yappLid,     cutoutsLid, type, "cutout", true);
   }
-  // All others can cross bewteen the two
+  //-- All others can cross bewteen the two
   processFaceList(yappLeft,    cutoutsLeft, type, "cutout", true);
   processFaceList(yappRight,   cutoutsRight, type, "cutout", true);
   processFaceList(yappFront,   cutoutsFront, type, "cutout", true);
   processFaceList(yappBack,    cutoutsBack, type, "cutout", true);
 
-} //makeCutouts()
+} //-- makeCutouts()
 
 
 //===========================================================
 module processCutoutList_Mask(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth,base_pos_H, base_pos_V, base_width, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ)
 {
-  // Check if there is a mask
+  //-- Check if there is a mask
   theMask = getVector(yappMaskDef, cutOut);    
   theMaskVector = getVectorInVector(yappMaskDef, cutOut);
   useMask = ((!theMask==false) || (!theMaskVector==false));
@@ -2000,10 +1938,10 @@ module processCutoutList_Mask(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, o
   {
     processCutoutList_Shape(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth,base_pos_H, base_pos_V, base_width, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ);
   }
-} //processCutoutList_Mask
+} //-- processCutoutList_Mask()
 
 //===========================================================
-// Process the list passeed in
+//-- Process the list passeed in
 module processCutoutList_Shape(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth,base_pos_H, base_pos_V, base_width, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ)
 {
   theRadius = cutOut[4];
@@ -2012,7 +1950,7 @@ module processCutoutList_Shape(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, 
   
   zShift = invertZ ? -base_depth : 0;
   
-  // Output all of the current parameters
+  //-- Output all of the current parameters
   if (printMessages) echo("base_pos_H",base_pos_H);
   if (printMessages) echo("base_pos_V",base_pos_V);
   if (printMessages) echo("base_width",base_width);
@@ -2053,7 +1991,7 @@ module processCutoutList_Shape(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, 
   
   if (printMessages) echo ("------------------------------");
     
-} //  processCutoutList_Shape()
+} //-- processCutoutList_Shape()
 
 
 //===========================================================
@@ -2062,12 +2000,9 @@ module processCutoutList_Face(face, cutoutList, casePart, swapXY, swapWH, invert
 {
   for ( cutOut = cutoutList )
   {
-    // Get the desired coordinate system    
+    //-- Get the desired coordinate system    
     theCoordSystem = getCoordSystem(cutOut, yappCoordPCB);   
    
-    // Get the PCB Name
-    thePCBName = getPCBName(yappPCBName, cutOut);
-
     theX = translate2Box_X (cutOut[0], face, theCoordSystem);
     theY = translate2Box_Y (cutOut[1], face, theCoordSystem);
     theWidth = cutOut[2];
@@ -2082,7 +2017,7 @@ module processCutoutList_Face(face, cutoutList, casePart, swapXY, swapWH, invert
     if (printMessages) echo("useCenterCoordinates", useCenterCoordinates);
     if (printMessages) echo("processCutoutList_Face", cutOut);
 
-    // Calc H&W if only Radius is given
+    //-- Calc H&W if only Radius is given
     tempWidth = (theShape == yappCircle) ?theRadius*2 : theWidth;
     tempLength = (theShape == yappCircle) ? theRadius*2 : theLength;
     
@@ -2092,7 +2027,7 @@ module processCutoutList_Face(face, cutoutList, casePart, swapXY, swapWH, invert
     base_pos_H  = ((!swapXY) ? theY : theX);
     base_pos_V  = ((!swapXY) ? theX : theY);
   
-    // Add 0.04 to the depth - we will shift by 0.02 later to center it on the wall
+    //-- Add 0.04 to the depth - we will shift by 0.02 later to center it on the wall
     base_depth  = (theDepth == 0) ? wallDepth + 0.04 : theDepth + 0.04;
     base_angle  = theAngle;
 
@@ -2102,7 +2037,7 @@ module processCutoutList_Face(face, cutoutList, casePart, swapXY, swapWH, invert
     
     processCutoutList_Mask(cutOut, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth, base_pos_H, base_pos_V, base_width, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ);
   } //for ( cutOut = cutoutList )
-} //processCutoutList_Face
+} //-- processCutoutList_Face()
 
 
 //===========================================================
@@ -2111,13 +2046,13 @@ module processRidgeExtList_Face(face, ridgeExtList, casePart, swapXY, swapWH, in
 {
   for ( ridgeExt = ridgeExtList )
   {
-    // Calculate based on the Coordinate system (test for Box override) thus defaulting to PCB
+    //-- Calculate based on the Coordinate system (test for Box override) thus defaulting to PCB
     theCoordSystem = getCoordSystem(ridgeExt, yappCoordPCB);
     thePCBName = getPCBName(yappPCBName, ridgeExt);
 
     useCenterCoordinates = isTrue(yappCenter, ridgeExt); 
     
-    // Convert x pos if needed
+    //-- Convert x pos if needed
     theX = translate2Box_X (ridgeExt[0], face, theCoordSystem);  
     theY =  baseWallHeight+basePlaneThickness;// RidgePos
     theWidth = ridgeExt[1];
@@ -2125,11 +2060,11 @@ module processRidgeExtList_Face(face, ridgeExtList, casePart, swapXY, swapWH, in
     
     originLLOpt = isTrue(yappLeftOrigin, ridgeExt);
     
-    // Calc H&W if only Radius is given
-    // add slack for the part connected to the lid
+    //-- Calc H&W if only Radius is given
+    //-- add slack for the part connected to the lid
     tempWidth = (subtract) ? theWidth : theWidth - ridgeSlack*2;
     
-    // Shift so that 0 aligns with the original seam
+    //-- Shift so that 0 aligns with the original seam
     tempLength = theY - theLength;
     
     base_width  = (swapWH) ? tempLength : tempWidth;
@@ -2141,7 +2076,7 @@ module processRidgeExtList_Face(face, ridgeExtList, casePart, swapXY, swapWH, in
     base_depth  = wallDepth;
     base_angle  = 0;
 
-    // Only adjust the H Pos for centering
+    //-- Only adjust the H Pos for centering
     pos_X = base_pos_H;
     pos_Y = (useCenterCoordinates) ? base_pos_V - (base_height/2) : base_pos_V + ((subtract) ? 0 : ridgeSlack);
 
@@ -2149,11 +2084,11 @@ module processRidgeExtList_Face(face, ridgeExtList, casePart, swapXY, swapWH, in
     
     processRidgeExtList(subtract, ridgeExt, casePart, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth, base_pos_H, base_pos_V, adjustedHeight, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ);
   } //for ( ridgeExt = ridgeExtList )
-} //processRidgeExtList_Face
+} //-- processRidgeExtList_Face()
 
 
 //===========================================================
-// Process the list passeed in
+//-- Process the list passeed in
 module processRidgeExtList(subtract, ridgeExt, casePart, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth,base_pos_H, base_pos_V, base_width, base_height, base_depth, base_angle, pos_X, pos_Y, invertZ)
 {
   apply = 
@@ -2193,14 +2128,14 @@ module processRidgeExtList(subtract, ridgeExt, casePart, rot_X, rot_Y, rot_Z, of
   
   else if (base_width <  ridgeHeight) 
   {
-    // Special Case
+    //-- Special Case
     drawWidth = (base_width > 0) 
-      ? ridgeHeight-base_width        // Positive
-      : ridgeHeight+base_width;       // Negative
+      ? ridgeHeight-base_width        //-- Positive
+      : ridgeHeight+base_width;       //-- Negative
     
     drawOffset = (base_width > 0) 
-      ? -ridgeHeight                   // Positive
-      : -ridgeHeight-base_width;       // Negative
+      ? -ridgeHeight                  //-- Positive
+      : -ridgeHeight-base_width;      //-- Negative
   
     translate([offset_x, offset_y, offset_z]) 
     {
@@ -2220,7 +2155,7 @@ module processRidgeExtList(subtract, ridgeExt, casePart, rot_X, rot_Y, rot_Z, of
       }// rotate
     } //translate
   }
-} //processRidgeExtList
+} //-- processRidgeExtList()
 
 
 //===========================================================
@@ -2262,19 +2197,19 @@ module processFaceList(face, list, casePart, listType, subtract)
     if (listType=="cutout") 
     {
       processCutoutList_Face(face, list, casePart, false, true, false, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth);
-    } // listType=="cutout"
+    } //-- listType=="cutout"
     else if (listType=="ridgeExt")
     {
       processRidgeExtList_Face(face, list, casePart, false, true, false, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth, subtract);
       
-    } // (listType=="ridgeExt") 
+    } //-- (listType=="ridgeExt") 
   }
   else if (face == yappRight) 
   {  
     if (printMessages) echo(str("Process ", listType, " on Right Face"));
-    rot_X = 90;      // Y
-    rot_Y = -90;     // X
-    rot_Z = 180;        // Z
+    rot_X = 90;      //-- Y
+    rot_Y = -90;     //-- X
+    rot_Z = 180;     //-- Z
     offset_x = 0;
     offset_y = shellWidth - (wallThickness);
     offset_z = (casePart==yappPartLid) ? -shellHeight : 0;
@@ -2292,9 +2227,9 @@ module processFaceList(face, list, casePart, listType, subtract)
   else if (face == yappFront) 
   {
     if (printMessages) echo(str("Process ", listType, " on Front Face"));
-    rot_X = 0;      // Y
-    rot_Y = -90;    // X
-    rot_Z = 0;      // Z
+    rot_X = 0;      //-- Y
+    rot_Y = -90;    //-- X
+    rot_Z = 0;      //-- Z
     offset_x = shellLength + wallThickness;
     offset_y = 0;
     offset_z = (casePart==yappPartLid) ? -shellHeight : 0;
@@ -2302,19 +2237,19 @@ module processFaceList(face, list, casePart, listType, subtract)
     if (listType=="cutout") 
     {
       processCutoutList_Face(face, list, casePart, false, true, false, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth);
-    } // listType=="cutout"
+    } //-- listType=="cutout"
     else if (listType=="ridgeExt")
     {
       processRidgeExtList_Face(face, list, casePart, false, true, false, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth, subtract);
       
-    } // (listType=="ridgeExt") 
+    } //-- (listType=="ridgeExt") 
   }
   else if (face == yappBack) 
   {
     if (printMessages) echo(str("Process ", listType, " on Back Face"));
-    rot_X = 0;      // Y
-    rot_Y = -90;    // X
-    rot_Z = 0;      // Z
+    rot_X = 0;      //-- Y
+    rot_Y = -90;    //-- X
+    rot_Z = 0;      ///-- Z
     offset_x = wallThickness; 
     offset_y = 0;
     offset_z = (casePart==yappPartLid) ? -shellHeight : 0;
@@ -2322,12 +2257,12 @@ module processFaceList(face, list, casePart, listType, subtract)
     if (listType=="cutout") 
     {
       processCutoutList_Face(face, list, casePart, false, true, true, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth);
-    } // listType=="cutout"
+    } //-- listType=="cutout"
     else if (listType=="ridgeExt")
     {
       processRidgeExtList_Face(face, list, casePart, false, true, true, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth, subtract);
       
-    } // (listType=="ridgeExt") 
+    } //-- (listType=="ridgeExt") 
   }
   else if (face == yappLid) 
   {
@@ -2342,7 +2277,7 @@ module processFaceList(face, list, casePart, listType, subtract)
     if (listType=="cutout") 
     {
       processCutoutList_Face(face, list, casePart, true, false, true, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth);
-    } // listType=="cutout"
+    } //-- listType=="cutout"
   }
   else if (face == yappBase) 
   {
@@ -2357,10 +2292,9 @@ module processFaceList(face, list, casePart, listType, subtract)
     if (listType=="cutout") 
     {
       processCutoutList_Face(face, list, casePart, true, false, false, rot_X, rot_Y, rot_Z, offset_x, offset_y, offset_z, wallDepth);
-    } // listType=="cutout"
-  }
-  
-} // processFaceList()
+    } //-- listType=="cutout"
+  } 
+} //-- processFaceList()
 
 
 //===========================================================
@@ -2374,8 +2308,9 @@ module screwHeadHole(conn)
   else
     linear_extrude(basePlaneThickness+0.04)
       circle(d = conn[4]);  //-- screwHeadDiam
-}
+} //-- screwHeadHole()
 
+//===========================================================
 module cutoutsForScrewHoles(type)
 {      
   for(conn = connectors)
@@ -2417,42 +2352,40 @@ module cutoutsForScrewHoles(type)
         screwHeadHole (conn);
     }     
   } // for conn ..  
-  
-} // cutoutsForScrewHoles()
+} //-- cutoutsForScrewHoles()
 
 
 //===========================================================
-
-              //
-              //        -->|             |<-- tubeLength and tubeWidth-->
-              //    --------             ----------------------------------------------------
-              //                                         # lidPlaneThickness             Leave .5mm is not yappThroughLid 
-              //    ----+--+             +--+---------------------------------------      
-              //        |  |             |  |   ^                    
-              //        |  |             |  |   |
-              //        |  |             |  |   #Tube Height
-              //        |  |             |  |   |
-              //        |  |             |  |   |
-              //        |  |             |  |   |
-              //        |  |             |  |   v
-              //        +--+             +--+   
-              //
-              //       #tAbvPcb
-              //        
-              //   +------------------------------------ topPcb 
-              //   |  # pcb_Thickness
-              //   +-+--+-------------------------------
-              //     |  | # standoff_Height
-              //-----+  +-------------------------------------
-              //              # basePlaneThickness
-              //---------------------------------------------
-
+//--
+//--        -->|             |<-- tubeLength and tubeWidth-->
+//--    --------             ----------------------------------------------------
+//--                                         # lidPlaneThickness             Leave .5mm is not yappThroughLid 
+//--    ----+--+             +--+---------------------------------------      
+//--        |  |             |  |   ^                    
+//--        |  |             |  |   |
+//--        |  |             |  |   #Tube Height
+//--        |  |             |  |   |
+//--        |  |             |  |   |
+//--        |  |             |  |   |
+//--        |  |             |  |   v
+//--        +--+             +--+   
+//--
+//--       #tAbvPcb
+//--        
+//--   +------------------------------------ topPcb 
+//--   |  # pcb_Thickness
+//--   +-+--+-------------------------------
+//--     |  | # standoff_Height
+//-- ----+  +-------------------------------------
+//--              # basePlaneThickness
+//-- ---------------------------------------------
+//-- 
 module lightTubeCutout()
 {
   for(tube=lightTubes)
   {
     if (printMessages) echo ("Tube Def",tube=tube);
-    // Get the desired coordinate system    
+    //-- Get the desired coordinate system    
     theCoordSystem = getCoordSystem(tube, yappCoordPCB);  
   
     standoff_Height = standoffHeight(theCoordSystem[2]);
@@ -2481,8 +2414,7 @@ module lightTubeCutout()
       processFaceList(yappLid, tmpArray, yappPartLid, "cutout", true);
     }
   } //-- for tubes
-  
-} //  lightTubeCutout()
+} //-- lightTubeCutout()
 
 
 //===========================================================
@@ -2490,7 +2422,7 @@ module buildLightTubes()
 {
   for(tube=lightTubes)
   {
-    // Get the desired coordinate system    
+    //-- Get the desired coordinate system    
     theCoordSystem = getCoordSystem(tube, yappCoordPCB);    
    
     standoff_Height = standoffHeight(theCoordSystem[2]);
@@ -2560,11 +2492,11 @@ module buildLightTubes()
     }
   } //--for(..)
   
-} //  buildLightTubes()
+} //-- buildLightTubes()
 
 
 //===========================================================
-// Create the cut through the lid
+//-- Create the cut through the lid
 module buttonCutout()
 {
   for(button=pushButtons)
@@ -2598,11 +2530,11 @@ module buttonCutout()
      processFaceList(yappLid, tmpArray, yappPartLid, "cutout", true);
   } //-- for buttons
   
-} //  buttonCutout()
+} //-- buttonCutout()
 
 
 //===========================================================
-// Create the cavity for the button
+//-- Create the cavity for the button
 module buildButtons(preCuts)
 {
   if (printMessages) echo("buildButtons(): process ", len(pushButtons)," buttons");
@@ -2808,8 +2740,7 @@ module buildButtons(preCuts)
       } // Post Cuts
     } //-- for buttons ..
   } //-- len(pushButtons) > 0
-  
-} //  buildButtons()
+} //-- buildButtons()
 
 
 //===========================================================
@@ -2827,15 +2758,12 @@ module drawLabels(casePart, subtract)
         : -baseWallHeight - basePlaneThickness
       : 0 ;
         
-    
-    //   Optional:
+    //-- Optional:
     expandBy = getParamWithDefault(label[8],0);
-      
-
 
     translate([shiftX, shiftY, shiftZ])
     {
-    // Check if the label is valid for the for subtract value 
+    //-- Check if the label is valid for the for subtract value 
     if (((label[3] > 0) && subtract) || ((label[3] < 0) && !subtract))
     {
       theDepth = (subtract) ? label[3] : -label[3];
@@ -2988,7 +2916,7 @@ module drawLabels(casePart, subtract)
     } // Translate
   } // for labels
   
-} //  drawLabels()
+} //-- drawLabels()
 
 
 //===========================================================
@@ -3029,20 +2957,19 @@ module baseShell()
           } // linear_extrude..
         } // translate()
       } // diff
-    } //  subtrbaseRidge()
+    } //-- subtrbaseRidge()
 
 //-------------------------------------------------------------------
    
   posZ00 = (baseWallHeight) + basePlaneThickness;
   
-  //echo("base:", posZ00=posZ00);
-   translate([(shellLength/2), shellWidth/2, posZ00])
+  translate([(shellLength/2), shellWidth/2, posZ00])
   {
     difference()  //(b) Remove the yappPartLid from the base
     {
       union()
       {
-        // Create the shell and add the Mounts and Hooks
+        //-- Create the shell and add the Mounts and Hooks
         minkowskiBox(yappPartBase, shellInsideLength, shellInsideWidth, baseWallHeight, roundRadius, basePlaneThickness, wallThickness, true);
         if ($preview) 
         {
@@ -3083,12 +3010,12 @@ module baseShell()
     } // difference(b)  
   } // translate
   
-  // Draw the objects that connect to the Base
+  //-- Draw the objects that connect to the Base
   pcbHolders();
   printSnapJoins(yappPartBase);
   shellConnectors(yappPartBase);
   makeRidgeExt(yappPartBase, false);
-} //  baseShell()
+} //-- baseShell()
 
 
 //===========================================================
@@ -3118,7 +3045,7 @@ module lidShell()
             }
         } // linear_extrude
       } //  translate  
-    } //  removeLidRidge()
+    } //-- removeLidRidge()
     //-------------------------------------------------------------------
 
   posZ00 = lidWallHeight+lidPlaneThickness;
@@ -3176,14 +3103,13 @@ module lidShell()
   shellConnectors(yappPartLid);
   buildLightTubes();
   buildButtons(true);
-} //  lidShell()
+} //-- lidShell()
 
         
 //===========================================================
 module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, configList) 
 {
-  
-  // Get the PCBinfo 
+  //-- Get the PCBinfo 
   thePCB = getPCBInfo(yappPCBName, configList);
  
   pcb_Length       = pcbLength(thePCB[0]); 
@@ -3226,7 +3152,7 @@ module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, con
             color(color,1.0) pinFillet(-thestandoff_Diameter/2, filletRadius);
         } // ifFillet
       }
-    } // standoff()
+    } //-- standoff()
         
     // **********************
     module standPin(color)
@@ -3241,7 +3167,7 @@ module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, con
           h = pcbGap+pcbStandHeight+thestandoff_PinDiameter,
           center = false); 
           }
-    } // standPin()
+    } //-- standPin()
     
     // **********************
     module standHole(color)
@@ -3252,7 +3178,6 @@ module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, con
         holeZ = (plane == yappPartBase)? pcbGap + 0.02 : -0.02;
         {
           color(color, 1.0)
-         // translate([0,0,0])
           union() {
             translate([0,0,filletZ]) 
               sphere(d = thestandoff_PinDiameter+.2+thestandoff_HoleSlack);
@@ -3273,15 +3198,15 @@ module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, con
           h = (pcbGap*2)+pcbStandHeight+0.02,
           center = false);
       }
-    } // standhole()
+    } //-- standhole()
     
     //--------------------------------------------------
-    if (type == yappPin)  // pin
+    if (type == yappPin)  //-- pin
     {
      standoff(color);
      standPin(color);
     }
-    else            // hole
+    else                  //-- hole
     {
       difference()
       {
@@ -3289,22 +3214,19 @@ module pcbStandoff(plane, pcbStandHeight, filletRad, type, color, useFillet, con
         standHole(color);
       }
     }     
-} // pcbStandoff()
+} //-- pcbStandoff()
 
         
 //===========================================================
 module connectorNew(shellPart, theCoordSystem, x, y, conn, outD) 
 {
-  //sH = conn[2]; //-- pcbStandHeight
   face = (shellPart==yappPartBase) ? yappBase : yappLid ;
   connHeightRaw = translate2Box_Z (conn[2], face, theCoordSystem);
-  //if the Coord System is PCB we need to shift to the bottom of the PCB 
+  //-- if the Coord System is PCB we need to shift to the bottom of the PCB 
   
   pcb_Thickness = pcbThickness(theCoordSystem[2]);
   
-  
-//  connHeight = (theCoordSystem[0]==yappCoordPCB) ? connHeightRaw - pcb_Thickness : connHeightRaw;
-  connHeight = (theCoordSystem[0]==yappCoordPCB) ? connHeightRaw - pcb_Thickness : connHeightRaw;
+    connHeight = (theCoordSystem[0]==yappCoordPCB) ? connHeightRaw - pcb_Thickness : connHeightRaw;
 
   d1 = conn[3]; //-- screw Diameter
   d2 = conn[4]; //-- screwHead Diameter
@@ -3371,7 +3293,7 @@ module connectorNew(shellPart, theCoordSystem, x, y, conn, outD)
           
         } //  difference
         
-        // Internal fillet
+        //-- Internal fillet
         if (!isTrue(yappNoFillet, conn) && !isTrue(yappCountersink, conn))
         {
           filletRadius = (d2-d1)/4; // 1/2 the width if the screw flange
@@ -3389,8 +3311,8 @@ module connectorNew(shellPart, theCoordSystem, x, y, conn, outD)
   
   if (shellPart==yappPartLid)
   {
-    // calculate the Z-position for the lid connector.
-    // for a PCB connector, start the connector on top of the PCB to push it down.
+    //-- calculate the Z-position for the lid connector.
+    //-- for a PCB connector, start the connector on top of the PCB to push it down.
     
     heightTemp = shellHeight-connHeight-pcbGap;
     zOffset = -heightTemp;
@@ -3437,7 +3359,7 @@ module connectorNew(shellPart, theCoordSystem, x, y, conn, outD)
       }
     } // translate
   } //  if lid
-} // connectorNew()
+} //-- connectorNew()
 
         
 //===========================================================
@@ -3448,7 +3370,7 @@ module shellConnectors(shellPart)
     allCorners = (isTrue(yappAllCorners, conn)) ? true : false;
     primeOrigin = (!isTrue(yappBackLeft, conn) && !isTrue(yappFrontLeft, conn) && !isTrue(yappFrontRight, conn) && !isTrue(yappBackRight, conn) && !isTrue(yappAllCorners, conn) ) ? true : false;
     
-    // Get the desired coordinate system    
+    //-- Get the desired coordinate system    
     theCoordSystem = getCoordSystem(conn, yappCoordPCB);    
     face = (shellPart==yappPartBase) ? yappBase : yappLid ;
  
@@ -3495,9 +3417,10 @@ module shellConnectors(shellPart)
       conn, 
       outD);
   } // for ..
-} // shellConnectors()
+} //-- shellConnectors()
 
 
+//===========================================================
 module showPCBs()
 {
   if ($preview) {
@@ -3506,7 +3429,7 @@ module showPCBs()
       printPCB(thePCB);
     }  
   }
-}
+} //--showPCBs()
 
 
 //===========================================================
@@ -3599,7 +3522,7 @@ module showOrientation()
             , halign="left"
             , valign="bottom");    
   }
-} // showOrientation()
+} //-- showOrientation()
 
 
 //===========================================================
@@ -3625,7 +3548,7 @@ module pinFillet(pinRadius, filletRadius)
           translate([xoffset, voffset2]) square(fr);
           circle(fr);
         }
-} //pinFillet()
+} //-- pinFillet()
 
 
 //===========================================================
@@ -3649,39 +3572,15 @@ module boxFillet (boxSize, filletRadius)
     }
     translate([0,0, fr]) cube(size=[(bs*2)-.04,(bs*2)-.04,fr*3], center=true);
   }
-} //boxFillet
-
-
-//===========================================================
-module boxFillet (boxSize, filletRadius) 
-{
-  fr = filletRadius;
-  voffset = (boxSize < 0) ? 0 : fr;
-  voffset2 = (boxSize < 0) ? -fr : 0;
-  bs = (boxSize < 0) ? -boxSize : boxSize;
-  translate([0,0, voffset2])
-  difference()
-  {
-    difference()
-    {
-      translate([0,0, fr/2]) cube(size=[(bs+fr)*2,(bs+fr)*2,fr], center=true);
-      for(dr=[0:90:270])
-        rotate([0,0,dr])
-        translate([bs+fr,0, voffset]) 
-        rotate([90,0,0]) cylinder(h=bs*5,
-        r=fr, center=true);
-    }
-    translate([0,0, fr]) cube(size=[(bs*2)-.04,(bs*2)-.04,fr*3], center=true);
-  }
-} //boxFillet
+} //-- boxFillet()
 
 
 //===========================================================
 module linearFillet(length, radius, rotation)
 {
-  // Spin it to the desired rotation
+  //-- Spin it to the desired rotation
   rotate([rotation,0,0])
-  // Bring it to normal orientation
+  //-- Bring it to normal orientation
   translate([length,0,0])  // x, Y, Z
   rotate ([0,-90,0]) 
   difference()
@@ -3691,12 +3590,12 @@ module linearFillet(length, radius, rotation)
     translate([radius,radius,-0.1]) 
       cylinder(h=length+0.2, r=radius, center=false);
   }
-} //linearFillet
+} //-- linearFillet()
 
 
 //===========================================================
-// Set boxWidth to negative to invert the fillet in the Z axis
-// Orientation  (0 = Normal 1= Flip in Z, 2 = flip inside
+//-- Set boxWidth to negative to invert the fillet in the Z axis
+//-- Orientation  (0 = Normal 1= Flip in Z, 2 = flip inside
 module rectangleFillet (boxWidth, boxLength, filletRadius, orientation=0)
 {  
   flipZ = (orientation % 2 >= 1 ) ? 1 : 0;
@@ -3736,7 +3635,7 @@ module rectangleFillet (boxWidth, boxLength, filletRadius, orientation=0)
   else
   {
     translate([0,0, voffset2])
-    // front/back
+    //-- front/back
     for(dr=[0,180])
     {
       rotate([0,0,dr])
@@ -3749,7 +3648,7 @@ module rectangleFillet (boxWidth, boxLength, filletRadius, orientation=0)
               cylinder(h=by*2 + (fr*5), r=fr, center=true);
       }
     }
-    //left right
+    //-- left right
     for(dr=[90,270])
     {
       rotate([0,0,dr])
@@ -3763,9 +3662,10 @@ module rectangleFillet (boxWidth, boxLength, filletRadius, orientation=0)
       }
     }
   }
-} //rectangleFillet
+} //-- rectangleFillet()
 
 
+//===========================================================
 module roundedRectangle2D(width,length,radius)
 {
   if (radius > width/2 || radius > length/2) 
@@ -3779,13 +3679,13 @@ module roundedRectangle2D(width,length,radius)
     translate ([(-width/2) + radius, (+length/2) - radius,0]) circle(r=radius);
     translate ([(+width/2) - radius, (+length/2) - radius,0]) circle(r=radius);
   }
-} //roundedRectangle2D
+} //-- roundedRectangle2D()
 
 
+//===========================================================
 module generateShapeFillet (Shape, useCenter, Width, Length, Depth, filletTop, filletBorrom, Radius, Rotation, Polygon=undef, expand=0)
-// Creates a shape centered at 0,0 in the XY and from 0-thickness in the Z with a fillet on the top and bottom (optional)
+//-- Creates a shape centered at 0,0 in the XY and from 0-thickness in the Z with a fillet on the top and bottom (optional)
 { 
-//  echo (Shape=Shape, Center=Center, Width=Width, Length=Length, Thickness=Thickness, Radius=Radius, Rotation=Rotation, Polygon=Polygon);
   Thickness = Depth;
   filletRadiusTop = filletTop; 
   filletRadiusBottom = filletBorrom; 
@@ -3793,7 +3693,6 @@ module generateShapeFillet (Shape, useCenter, Width, Length, Depth, filletTop, f
   rotate([0,0,Rotation])
   {
     extrudeWithRadius(Thickness,filletRadiusBottom,-filletRadiusTop,Thickness/printerLayerHeight)  
-  //  linear_extrude(height = Thickness)
     {
       offset(expand)
       { 
@@ -3851,10 +3750,10 @@ module generateShapeFillet (Shape, useCenter, Width, Length, Depth, filletTop, f
       }
     }
   }
-} //generateShape
+} //-- generateShape()
 
 
-
+//===========================================================
 module generateShape (Shape, useCenter, Width, Length, Thickness, Radius, Rotation, Polygon, expand=0)
 // Creates a shape centered at 0,0 in the XY and from 0-thickness in the Z
 { 
@@ -3919,9 +3818,10 @@ module generateShape (Shape, useCenter, Width, Length, Thickness, Radius, Rotati
       } // offset
     } // extrude
   } // Rotate
-} //generateShape
+} //-- generateShape()
 
 
+//===========================================================
 module genMaskfromParam(params, width, height, depth, hOffset, vOffset, addRot) 
 {  
   if (printMessages) echo("Mask");
@@ -3945,9 +3845,10 @@ module genMaskfromParam(params, width, height, depth, hOffset, vOffset, addRot)
     thePolygon //polygon)
     );
   
-} //genMaskfromParam
+} //-- genMaskfromParam()
 
 
+//===========================================================
 module genMask(pattern, width, height, hOffset, vOffset, thickness, hRepeat, vRepeat, rotation, openingShape, openingWidth, openingLength, openingRadius, openingRotation, polygon)
 {
   
@@ -4015,13 +3916,14 @@ module genMask(pattern, width, height, hOffset, vOffset, thickness, hRepeat, vRe
       }
     } 
   }
-} // genMask
+} //-- genMask()
 
 
+//===========================================================
 module drawLid() 
 {
 //-- Draw objects not cut by the lid
-//-- Comment out difference() to see objects instead of cutting them from the lid 
+//-- Comment out difference() to see objects instead of cutting them from the lid for debugging
 //-- xxxxx        
   difference()  // (t1) 
   {
@@ -4043,19 +3945,14 @@ module drawLid()
     
   } //  difference(t1)
   
-  // Post cutouts operations
-  
-//  // Add button extenders
-//  buildButtons(false);
-  
-  // post cutout hook
+  //-- Post cutouts operations
   posZ00 = lidWallHeight+lidPlaneThickness;
   translate([(shellLength/2), (shellWidth/2), (posZ00*-1)])
   {
     minkowskiBox(yappPartLid, shellInsideLength,shellInsideWidth, lidWallHeight, roundRadius, lidPlaneThickness, wallThickness, false);
   }
   
-  // Add the text
+  //-- Add the text
   translate([shellLength-15, -15, 0])
     linear_extrude(1) 
       mirror([1,0,0])
@@ -4065,15 +3962,16 @@ module drawLid()
               , direction="ltr"
               , halign="left"
               , valign="bottom");
-} //drawLid
+} //-- drawLid()
 
 
+//===========================================================
 module drawCenterMarkers()
 {
   if (showMarkersCenter) 
   {
     echo("SHOWING CENTER MARKERS");
-    // Left
+    //-- Left
     color("Magenta")
       translate([shellLength/2,0,shellHeight/2])
         rotate([0,0,45])
@@ -4083,7 +3981,7 @@ module drawCenterMarkers()
         rotate([0,90,0])
         rotate([0,0,45])
           cube([1,1,shellLength], center=true);
-    // Right
+    //-- Right
     color("Magenta")
       translate([shellLength/2,shellWidth,shellHeight/2])
         rotate([0,0,45])
@@ -4093,7 +3991,7 @@ module drawCenterMarkers()
         rotate([0,90,0])
         rotate([0,0,45])
           cube([1,1,shellLength], center=true);
-    // Front
+    //-- Front
     color("Magenta")
       translate([shellLength,shellWidth/2,shellHeight/2])
         rotate([0,0,45])
@@ -4103,7 +4001,7 @@ module drawCenterMarkers()
         rotate([90,0,0])
         rotate([0,0,45])
           cube([1,1,shellWidth], center=true);
-    // Back
+    //-- Back
     color("Magenta")
       translate([0,shellWidth/2,shellHeight/2])
         rotate([0,0,45])
@@ -4113,7 +4011,7 @@ module drawCenterMarkers()
         rotate([90,0,0])
         rotate([0,0,45])
           cube([1,1,shellWidth], center=true);
-    // Top
+    //-- Top
     color("Magenta")
       translate([shellLength/2,shellWidth/2,shellHeight])
         rotate([0,90,0])
@@ -4124,7 +4022,7 @@ module drawCenterMarkers()
         rotate([0,90,90])
         rotate([0,0,45])
           cube([1,1,shellWidth], center=true);
-    // Bottom
+    //-- Bottom
     color("Magenta")
       translate([shellLength/2,shellWidth/2,0])
         rotate([0,90,0])
@@ -4136,8 +4034,9 @@ module drawCenterMarkers()
         rotate([0,0,45])
           cube([1,1,shellWidth], center=true);
   }
-}
+}//-- drawCenterMarkers()
 
+//===========================================================
 module genOriginBars(color1, color2, coordSystem)
 {
   // Main origins on base
@@ -4147,11 +4046,12 @@ module genOriginBars(color1, color2, coordSystem)
   {
     translate([0,(shellWidth+shiftLid)*2 ,shellHeight])
     rotate([180,0,0])
-   // Alternate origins on lid
     genOriginPart(color1, color2, coordSystem);
-  }   
-  
-}
+  }    
+}//-- genOriginBars()
+
+
+//===========================================================
 module genOriginPart(color1, color2, coordSystem)
 {
   origin=(coordSystem[0]==yappCoordBox) ? [0,0,0]
@@ -4168,11 +4068,14 @@ module genOriginPart(color1, color2, coordSystem)
     translate([0,-origin[1],0])
     rotate([-90,0,0])
       genMarkerBar(color1, color2, "Y");
-    // Z doesn't need to rotate 
+    //-- Z doesn't need to rotate 
     translate([0,0,-origin[2]])
     genMarkerBar(color1, color2, "Z");
   }
-}
+}//-- genOriginPart()
+
+
+//===========================================================
 module genMarkerBar(color1, color2, axis )
 {
     barLength= (axis == "X") ? shellLength
@@ -4201,7 +4104,7 @@ module genMarkerBar(color1, color2, axis )
               h = 10,
               center = true);
   }
-}
+}//-- genMarkerBar()
 
 
 //===========================================================
@@ -4266,11 +4169,9 @@ module YAPPgenerate()
   }
   echo("YAPP==========================================");
 
-
-
   $fn=facetCount;
   
-  // Perform sanity checks
+  //-- Perform sanity checks
   sanityCheckList(pcbStands, "pcbStands", 2);
   sanityCheckList(connectors, "connectors", 7);
   sanityCheckList(boxMounts, "boxMounts", 4);
@@ -4319,7 +4220,7 @@ module YAPPgenerate()
         if (printMessages) echo ("* Print base *");
 // ****************************************************************               
 // xxxxx
-// Comment out difference() to see objects instead of cutting them from the base 
+// Comment out difference() to see objects instead of cutting them from the base for debugging
         difference()  // (a)
         {
        
@@ -4447,10 +4348,10 @@ module YAPPgenerate()
       } //inspectZ
     } // $preview
   }// Inspection cuts 
-} //  YAPPgenerate()
+} //-- YAPPgenerate()
 
 
-//module makeSwitchExtender(shape, capLength, capWidth, thickness, poleDiam, extHeight, aboveLid, thePolygon)
+//===========================================================
 module makeSwitchExtender(shape, capLength, capWidth, capRadius, thickness, poleDiam, extHeight, aboveLid, thePolygon)
 {
   
@@ -4483,9 +4384,10 @@ module makeSwitchExtender(shape, capLength, capWidth, capRadius, thickness, pole
     translate([0, 0, (extHeight/-2)-thickness]) 
       color("orange")
         cylinder(d=(poleDiam-(buttonSlack)), h=extHeight, center=true);
-} // makeSwitchExtender()
+} //-- makeSwitchExtender()
 
 
+//===========================================================
 //-- switch Plate -----------
 module makeSwitchPlate(poleDiam, thickness)
 {               
@@ -4506,9 +4408,10 @@ module makeSwitchPlate(poleDiam, thickness)
       color("blue")
         cylinder(h=thickness, d=poleDiam-(buttonSlack)+0.2, center=true);
   }    
-} // makeSwitchPlate
+} //-- makeSwitchPlate
 
 
+//===========================================================
 module drawSwitchOnPCB(thePCB)
 {
   if (len(pushButtons) > 0)
@@ -4541,16 +4444,54 @@ module drawSwitchOnPCB(thePCB)
         }
     }
   }
-} //drawSwitchOnPCB
+} //-- drawSwitchOnPCB
 
 
-// ----- Global Functions ----- 
+
+//===========================================================
+//===========================================================
+// General functions
+//===========================================================
+//===========================================================
+
+function getMinRad(p1, wall) = ((p1<(wall)) ? 1 : (p1 - wall));
+
+// Check the first 21 elements in an array (I don't think any will be over 21)
+function isTrue(constantValue, setArray) = (
+  (   setArray[0] == constantValue 
+   || setArray[1] == constantValue 
+   || setArray[2] == constantValue 
+   || setArray[3] == constantValue 
+   || setArray[4] == constantValue 
+   || setArray[5] == constantValue 
+   || setArray[6] == constantValue 
+   || setArray[7] == constantValue 
+   || setArray[8] == constantValue 
+   || setArray[9] == constantValue 
+   || setArray[10] == constantValue 
+   || setArray[11] == constantValue 
+   || setArray[12] == constantValue 
+   || setArray[13] == constantValue 
+   || setArray[14] == constantValue 
+   || setArray[15] == constantValue 
+   || setArray[16] == constantValue 
+   || setArray[17] == constantValue 
+   || setArray[18] == constantValue 
+   || setArray[19] == constantValue ) ? 1 : 0);  
+   
+//===========================================================
+ 
+function minOutside(ins, outs) = ((((ins*1.5)+0.2)>=outs) ? (ins*1.5)+0.2 : outs);  
+
+function countersinkHeight(conn) = (conn[4] / 2) / tan (countersinkAngle / 2);
+
 function maxLength(v, i = 0, r = 0) = i < len(v) ? maxLength(v, i + 1, max(r, v[i][1] + v[i][3])) : r;
 function maxWidth(v, i = 0, r = 0) = i < len(v) ? maxWidth(v, i + 1, max(r, v[i][2] + v[i][4])) : r;
 
 function pcbByName(pcbName="Main") = getVectorBase(pcbName, pcb);
 
 function getPCBInfo(yappPCBName, vector) = (getVector(yappPCBName, vector) == false) ? pcbByName("Main") : pcbByName(getVector(yappPCBName, vector));
+
 function getPCBName(yappPCBName, vector) = (getVector(yappPCBName, vector) == false) ? "Main" : pcbByName(getVector(yappPCBName, vector))[0];
 
 function getPCB_X(pcbName="Main") = (getVectorBase(pcbName, pcb))[3] + wallThickness + paddingFront; 
@@ -4568,7 +4509,6 @@ function standoffHeight(pcbName="Main") = (getVectorBase(pcbName, pcb))[6];
 function standoffDiameter(pcbName="Main") = (getVectorBase(pcbName, pcb))[7]; 
 function standoffPinDiameter(pcbName="Main") = (getVectorBase(pcbName, pcb))[8]; 
 function standoffHoleSlack(pcbName="Main") = (getVectorBase(pcbName, pcb))[9]; 
-
 
 function getParamWithDefault (theParam, theDefault) =
 (
@@ -4764,9 +4704,20 @@ function getHeight(sourceSystem) =
   (sourceSystem == yappCoordBox) ? shellHeight :
   undef;
 
-//=============================
+//===========================================================
+//===========================================================
+// End of General functions
+//===========================================================
+//===========================================================
+
+
+//===========================================================
+//===========================================================
 // Beginning of test modules 
-  
+//===========================================================
+//===========================================================
+ 
+//=========================================================== 
 module TestCoordTranslations()
 {
   module TestPCB2Box(x,y,z, face, sourceCoord)
@@ -4829,6 +4780,7 @@ module TestCoordTranslations()
 
 //TestCoordTranslations();
 
+//===========================================================
 // Test module for making masks
 module SampleMask(theMask)
 {
@@ -4837,6 +4789,7 @@ module SampleMask(theMask)
 }
 //SampleMask( maskHoneycomb);
 
+//===========================================================
 // Test module for making Polygons
 module SamplePolygon(thePolygon)
 {
@@ -4850,8 +4803,11 @@ module SamplePolygon(thePolygon)
 //SamplePolygon( shape6ptStar);
 
 
+//===========================================================
+//===========================================================
 // End of test modules 
-//=============================  
+//===========================================================
+//===========================================================
 
 //---- This is where the magic happens ----
 if (debug) 
@@ -4901,6 +4857,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Only part of round-anything is used
 function sq(x)=x*x;
 
+//===========================================================
 module extrudeWithRadius(length,r1=0,r2=0,fn=30){
   n1=sign(r1);n2=sign(r2);
   r1=abs(r1);r2=abs(r2);
@@ -4925,4 +4882,4 @@ module extrudeWithRadius(length,r1=0,r2=0,fn=30){
       }
     }
   }
-}
+} //-- extrudeWithRadius()

--- a/examples/Multiple_PCB_v30.scad
+++ b/examples/Multiple_PCB_v30.scad
@@ -15,7 +15,7 @@
 //
 //-----------------------------------------------------------------------
 
-include <./YAPPgenerator_v3.scad>
+include <../YAPPgenerator_v3.scad>
 
 //---------------------------------------------------------
 // This design is parameterized based on the size of a PCB.
@@ -54,12 +54,10 @@ printSwitchExtenders  = true;
 
 // ********************************************************************
 // The Following will be used as the first element in the pbc array
-
-//Defined here so you can define the "Main" PCB using these if wanted
-pcbLength           = 150; // front to back (X axis)
-pcbWidth            = 100; // side to side (Y axis)
-pcbThickness        = 1.6; 
-standoffHeight      = 1.0; //-- How much the PCB needs to be raised from the base to leave room for solderings and whatnot
+pcbLength           = 88.9; // Front to back
+pcbWidth            = 52.1; // Side to side
+pcbThickness        = 1.6;
+standoffHeight      = 3.0;  //-- How much the PCB needs to be raised from the base to leave room for solderings and whatnot
 standoffDiameter    = 7;
 standoffPinDiameter = 2.4;
 standoffHoleSlack   = 0.4;
@@ -78,11 +76,11 @@ standoffHoleSlack   = 0.4;
 //    p(3) = posx
 //    p(4) = posy
 //    p(5) = Thickness
-//    p(6) = standoff_Height
-//    p(7) = standoff_Diameter
-//    p(8) = standoff_PinDiameter
+//    p(6) = standoffHeight
+//    p(7) = standoffDiameter
+//    p(8) = standoffPinDiameter
+//    p(9) = standoffHoleSlack (default to 0.4)
 //   Optional:
-//    p(9) = standoff_HoleSlack (default to 0.4)
 
 //The following can be used to get PCB values elsewhere in the script - not in pcb definition. 
 //If "PCB Name" is omitted then "Main" is used
@@ -96,16 +94,22 @@ standoffHoleSlack   = 0.4;
 
 pcb = 
 [
-  // Default Main PCB - DO NOT REMOVE the "Main" line.
   ["Main",              pcbLength,pcbWidth,    0,0,    pcbThickness,  standoffHeight, standoffDiameter, standoffPinDiameter, standoffHoleSlack]
+ ,["Voltage Detect 1",  15.1,71.5+3,  pcbLength + 2,        0,  1.6,  3, 7, 2.4]
+ ,["Voltage Detect 2",  15.1,71.5+3,  pcbLength + 4 + 15.1, 0,  1.6,  3, 7, 2.4]
 ];
 
-//-------------------------------------------------------------------                            
+//-------------------------------------------------------------------
+
+
+
+
+  
 //-- padding between pcb and inside wall
-paddingFront        = 2;
-paddingBack         = 2;
-paddingRight        = 2;
-paddingLeft         = 2;
+paddingFront        = 1;
+paddingBack         = 1;
+paddingRight        = 1;
+paddingLeft         = 1;
 
 //-- Edit these parameters for your own box dimensions
 wallThickness       = 2.0;
@@ -118,8 +122,8 @@ lidPlaneThickness   = 1.5;
 //                       + basePlaneThickness
 //-- space between pcb and lidPlane :=
 //--      (bottonWallHeight+lidWallHeight) - (standoffHeight+pcbThickness)
-baseWallHeight      = 25;
-lidWallHeight       = 23;
+baseWallHeight      = 6;
+lidWallHeight       = 20;
 
 //-- ridge where base and lid off box can overlap
 //-- Make sure this isn't less than lidWallHeight
@@ -130,6 +134,9 @@ roundRadius         = 3.0;
 
 // Set the layer height of your printer
 printerLayerHeight  = 0.2;
+
+
+
 
 
 //---------------------------
@@ -149,8 +156,8 @@ alphaBase                 = 1;
 hideLidWalls              = false;      //-> Remove the walls from the lid : only if preview and showSideBySide=true 
 hideBaseWalls             = false;      //-> Remove the walls from the base : only if preview and showSideBySide=true  
 showOrientation           = true;       //-> Show the Front/Back/Left/Right labels : only in preview
-showPCB                   = false;      //-> Show the PCB in red : only in preview 
-showSwitches              = false;      //-> Show the switches (for pushbuttons) : only in preview 
+showPCB                   = true;      //-> Show the PCB in red : only in preview 
+showSwitches              = true;      //-> Show the switches (for pushbuttons) : only in preview 
 showButtonsDepressed      = false;      //-> Should the buttons in the Lid On view be in the pressed position
 showOriginCoordBox        = false;      //-> Shows red bars representing the origin for yappCoordBox : only in preview 
 showOriginCoordBoxInside  = false;      //-> Shows blue bars representing the origin for yappCoordBoxInside : only in preview 
@@ -206,25 +213,36 @@ inspectZfromBottom        = true;       //-> View from the inspection cut up
 //    p(0) = posx
 //    p(1) = posy
 //   Optional:
-//    p(2) = Height to bottom of PCB : Default = standoffHeight
-//    p(3) = PCB Gap : Default = -1 : Default for yappCoordPCB=pcbThickness, yappCoordBox=0
-//    p(4) = standoffDiameter    Default = standoffDiameter;
-//    p(5) = standoffPinDiameter Default = standoffPinDiameter;
-//    p(6) = standoffHoleSlack   Default = standoffHoleSlack;
+//    p(2) = Height to bottom of PCB : Default = standoff_Height
+//    p(3) = PCB Gap : Default = -1 : Default for yappCoordPCB=pcb_Thickness, yappCoordBox=0
+//    p(4) = standoff_Diameter    Default = standoff_Diameter;
+//    p(5) = standoff_PinDiameter Default = standoff_PinDiameter;
+//    p(6) = standoff_HoleSlack   Default = standoff_HoleSlack;
 //    p(7) = filletRadius (0 = auto size)
 //    n(a) = { <yappBoth> | yappLidOnly | yappBaseOnly }
 //    n(b) = { <yappPin>, yappHole } // Baseplate support treatment
-//    n(c) = { <yappAllCorners>, yappFrontLeft | yappFrontRight | yappBackLeft | yappBackRight }
+//    n(c) = { yappAllCorners, yappFrontLeft | <yappBackLeft> | yappFrontRight | yappBackRight }
 //    n(d) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside }
 //    n(e) = { yappNoFillet }
+//    n(f) = [yappPCBName, "XXX"] : {Specify a PCB defaults to "Main"
 //-------------------------------------------------------------------
 pcbStands = 
 [
 //- Add stands 5mm from each corner of the PCB
-    [5, 5]
+    [5, 5, yappAllCorners]
 //-   Add posts 25mm from the corners of the box, with a custon height,diameter, Pin Size, hole
 //-   slack and filler radius.
 //  [25, 25, 10, 10, 3.3, 0.9, 5, yappCoordBox] 
+//  [5,5, yappAllCorners]
+
+  // Voltage Dector boards have 2 offset pins
+ ,[ 8.5,15.4, undef, undef, 5, 2.5, [yappPCBName, "Voltage Detect 1"]]
+ ,[12.5,55.7, undef, undef, 5, 2.5, [yappPCBName, "Voltage Detect 1"]]
+
+ ,[ 8.5,15.4, undef, undef, 5, 2.5, [yappPCBName, "Voltage Detect 2"]]
+ ,[12.5,55.7, undef, undef, 5, 2.5, [yappPCBName, "Voltage Detect 2"]]
+
+
 ];
 
 
@@ -249,13 +267,11 @@ pcbStands =
 //    n(a) = { <yappAllCorners>, yappFrontLeft | yappFrontRight | yappBackLeft | yappBackRight }
 //    n(b) = { <yappCoordBox> | yappCoordPCB |  yappCoordBoxInside }
 //    n(c) = { yappNoFillet }
+//    n(d) = [yappPCBName, "XXX"] : {XXX = the PCB name: Default "Main"}
 //-------------------------------------------------------------------
 connectors   =
 [
-    [9, 15, 10, 2.5, 6 + 1.25, 4.0, 9, 4, yappFrontRight, yappCountersink]
-//   ,[9, 15, 10, 2.5, 6 + 1.25, 4.0, 9, yappNoFillet, yappFrontLeft]
-//   ,[34, 15, 10, 2.5, 6+ 1.25, 4.0, 9, yappFrontRight]
-//   ,[34, 15, 10, 2.5, 6+ 1.25, 4.0, 9, 0, yappFrontLeft]
+//  [9, 15, standoffHeight("PCB3"), 2.5, 6 + 1.25, 4.0, 9, yappAllCorners, [yappPCBName, "PCB3"]]
 ];
 
 
@@ -299,46 +315,43 @@ connectors   =
 //    n(d) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside }
 //    n(e) = { <yappOrigin>, yappCenter }
 //    n(f) = { <yappGlobalOrigin>, yappLeftOrigin } // Only affects Top(lid), Back and Right Faces
+//    n(g) = [yappPCBName, "XXX"] : {Specify a PCB defaults to "Main"
 //-------------------------------------------------------------------
 cutoutsBase = 
 [
-  [65,shellWidth/2 ,55,55, 5, yappPolygon ,0 ,30, yappCenter, shapeHexagon, maskHexCircles]
-// , [0, 0, 10, 10, 0, yappRectangle,maskHexCircles]
+  [pcbLength()/2,shellWidth/2 ,55,55, 5, yappPolygon ,0 ,0, yappCenter, shapeHexagon, [maskHoneycomb,0,1.5,0], ]
+// , [0, 0, 10, 10, 0, yappRectangle, maskHexCircles, [yappPCBName, "PCB3"]]
 // , [shellLength*2/3,shellWidth/2 ,0, 30, 20, yappCircleWithFlats, yappCenter]
 // , [shellLength/2,shellWidth/2 ,10, 5, 20, yappCircleWithKey,yappCenter]
 ];
 
 cutoutsLid  = 
 [
-//Center test
-  [shellLength/2,   shellWidth/2,  1,  1,  5, yappRectangle ,20 ,45, yappCenter]
- ,[pcbLength/2,       pcbWidth/2,  1,  1,  5, yappRectangle ,20 ,45, yappCenter, yappCoordPCB]
-//Edge tests
- ,[shellLength/2,              0,  2,  2,  5, yappRectangle ,20 ,45, yappCenter]
- ,[shellLength/2,     shellWidth,  2,  2,  5, yappRectangle ,20 ,45, yappCenter]
- ,[0,               shellWidth/2,  2,  2,  5, yappRectangle ,20 ,45, yappCenter]
- ,[shellLength,     shellWidth/2,  2,  2,  5, yappRectangle ,20 ,45, yappCenter]
-
- ,[shellLength*2/3, shellWidth/2,  0, 30, 20, yappCircleWithFlats, yappCenter]
- ,[shellLength/3,   shellWidth/2, 10,  5, 20, yappCircleWithKey,yappCenter]
-
 ];
 
 cutoutsFront =  
 [
 ];
 
-
 cutoutsBack = 
 [
+  // Cutout for USB
+ [pcbWidth()/2, 13 -pcbThickness() ,12.5,7.0, 2, yappRoundedRect , yappCenter]
 ];
 
 cutoutsLeft =   
 [
+  // Cutout for AC 1
+  [pcbLength("Voltage Detect 1")/2, pcbThickness("Voltage Detect 1") + 3 ,11,7.0, 2, yappRoundedRect , yappCenter, [yappPCBName, "Voltage Detect 1"]]
+  // Cutout for AC 2
+ ,[pcbLength("Voltage Detect 2")/2, pcbThickness("Voltage Detect 2") + 3 ,11,7.0, 2, yappRoundedRect , yappCenter, [yappPCBName, "Voltage Detect 2"]]
+
 ];
 
 cutoutsRight =  
 [
+ [pcbLength()/2, pcbThickness() + 3 ,12.5,7.0, 2, yappRoundedRect , yappCenter]
+
 ];
 
 
@@ -360,9 +373,10 @@ cutoutsRight =
 //-------------------------------------------------------------------
 snapJoins   =   
 [
-    [15, 10, yappFront, yappCenter,    yappRectangle, yappSymmetric]
-   ,[25, 10, yappBack,  yappSymmetric, yappCenter]
-   ,[30, 10, yappLeft,  yappRight,     yappCenter,    yappSymmetric]
+    [15, 10, yappFront, yappCenter, yappSymmetric]
+   ,[15, 10, yappBack,  yappCenter, yappSymmetric]
+   ,[30, 10, yappRight, yappCenter, yappSymmetric]
+   ,[45, 10, yappLeft,  yappCenter, yappSymmetric]
 ];
 
 //===================================================================
@@ -414,28 +428,42 @@ boxMounts =
 //    n(a) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside } 
 //    n(b) = { <yappGlobalOrigin>, yappLeftOrigin }
 //    n(c) = { yappNoFillet }
+//    n(d) = [yappPCBName, "XXX"] : {Specify a PCB defaults to "Main"
 //-------------------------------------------------------------------
 lightTubes =
 [
-  [(pcbLength/2)+10, 20,    // [0,1] Pos
-    5, 5,                   // [2,3] Length, Width
-    1,                      // [4]   wall thickness
-    standoffHeight + pcbThickness + 4, // [5] Gap above base bottom
-    yappRectangle,          // [6]   tubeType (Shape)
-    0.5,                    // [7]   lensThickness
+// ESP Power Light
+  [12.5 + 3, (pcbWidth()/2)+7.0,    // [0,1] Pos
+    3, 3,                   // [2,3] Length, Width
+    0.8,                      // [4]   wall thickness
+    standoffHeight() + pcbThickness() + 12, // [5] Gap above base bottom
+    yappCircle,          // [6]   tubeType (Shape)
+    0,                    // [7]   lensThickness
     yappCoordPCB            // [n1]
   ]
-  ,
-  [(pcbLength/2)+10, 40,    // [0,1] Pos
-    5, 10,                  // [2,3] Length, Width
-    1,                      // [4]   wall thickness
-    standoffHeight + pcbThickness + 4, // [5] Gap above base bottom
-    yappCircle,             // [6]   tubeType (Shape)
-    undef,                  // [7]
-    undef,                  // [8]
-    5,                      // [9]   filletRadius
+  
+// Voltage Detect 1 power indicator
+ ,[pcbLength("Voltage Detect 1")/2, 30,    // [0,1] Pos
+    6, 6,                   // [2,3] Length, Width
+    0.8,                      // [4]   wall thickness
+    5, // [5] gapAbovePcb
+    yappCircle,          // [6]   tubeType (Shape)
+    0,                    // [7]   lensThickness
     yappCoordPCB            // [n1]
+    ,[yappPCBName, "Voltage Detect 1"]
   ]
+  
+// Voltage Detect 2 power indicator
+ ,[pcbLength("Voltage Detect 2")/2, 30,    // [0,1] Pos
+    6, 6,                   // [2,3] Length, Width
+    0.8,                      // [4]   wall thickness
+    5, // [5] Gap above base bottom
+    yappCircle,          // [6]   tubeType (Shape)
+    0,                    // [7]   lensThickness
+    yappCoordPCB            // [n1]
+    ,[yappPCBName, "Voltage Detect 2"]
+  ]
+  
 ];
 
 //===================================================================
@@ -466,12 +494,26 @@ lightTubes =
 //    n(a) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside } 
 //    n(b) = { <yappGlobalOrigin>,  yappLeftOrigin }
 //    n(c) = { yappNoFillet }
+//    n(d) = [yappPCBName, "XXX"] : {Specify a PCB defaults to "Main"
 //-------------------------------------------------------------------
 pushButtons = 
 [
-//-               0,   1,  2,  3, 4, 5,   6, 7, 8
-   [(pcbLength/2)+10, 65, 15, 10, 0, 3,   5, 1, 3]
-  ,[(pcbLength/2)+10, 85, 10, 10, 4, 2.0, 4, 1, 4, standoffHeight, yappCircle]
+  // ESP Reset Button
+  [2.54 + 3, (pcbWidth()/2)+7.0, 
+    8, // Width
+    8, // Length
+    2, // Radius
+    0, // Cap above Lid
+    15, // Switch Height
+    0.5, // Switch travel
+    3, // Pole Diameter
+    undef, // Height to top of PCB
+    yappRoundedRect // Shape
+   ] 
+    
+//-                 0,   1,  2,  3, 4, 5,   6, 7, 8
+//   [(pcbLength()/2)+10, 65, 15, 10, 0, 3,   5, 1, 3]
+//  ,[                10, 10, 10, 10, 4, 2.0, 4, 1, 4, standoffHeight(), yappCircle, [yappPCBName, "PCB3"]]
 ];
              
 //===================================================================
@@ -513,15 +555,20 @@ labelsPlane =
 //    n(a) = { <yappOrigin>, yappCenter } 
 //    n(b) = { <yappCoordPCB> | yappCoordBox | yappCoordBoxInside }
 //    n(c) = { yappLeftOrigin, <yappGlobalOrigin> } // Only affects Top(lid), Back and Right Faces
+//    n(d) = [yappPCBName, "XXX"] : {Specify a PCB defaults to "Main"
 //
 // Note: Snaps should not be placed on ridge extensions as they remove the ridge to place them.
 //-------------------------------------------------------------------
 ridgeExtLeft =
 [
+  [pcbLength("Voltage Detect 1")/2, 11, pcbThickness("Voltage Detect 1") + 3, [yappPCBName, "Voltage Detect 1"], yappCenter]
+ ,[pcbLength("Voltage Detect 2")/2, 11, pcbThickness("Voltage Detect 2") + 3, [yappPCBName, "Voltage Detect 2"], yappCenter]
 ];
 
 ridgeExtRight =
 [
+  [pcbLength()/2, 12.5, pcbThickness() + 3 , yappCenter]
+
 ];
 
 ridgeExtFront =
@@ -530,7 +577,9 @@ ridgeExtFront =
 
 ridgeExtBack =
 [
+  [pcbWidth()/2, 12.5, 13,yappCoordPCB, yappCenter]
 ];
+
 
 
 //========= HOOK functions ============================


### PR DESCRIPTION
The normal PCB info can still be used for a single PCB box.

But if you want to add additional PCBs you now can easily.

New structure to define additional PCBs "pcb" may optionally be defined. But if not then all existing v3 scripts should work without modifications using the existing parameters.

All features that support the yappCoordPCB option can now optionally specify what PCB to use as the reference board. If none is specified then the "Main" board is used.  

```
// ******************************************************************** // The Following will be used as the first element in the pbc array

//Defined here so you can define the "Main" PCB using these if wanted
pcbLength           = 150; // front to back (X axis)
pcbWidth            = 100; // side to side (Y axis)
pcbThickness        = 1.6;
standoffHeight      = 1.0; //-- How much the PCB needs to be raised from the base to leave room for solderings and whatnot
standoffDiameter    = 7;
standoffPinDiameter = 2.4;
standoffHoleSlack   = 0.4;

//=================================================================== // *** PCBs ***
// Printed Circuit Boards
//------------------------------------------------------------------- //  Default origin =  yappCoordPCB : yappCoordBoxInside[0,0,0] //
//  Parameters:
//   Required:
//    p(0) = name
//    p(1) = length
//    p(2) = width
//    p(3) = posx
//    p(4) = posy
//    p(5) = Thickness
//    p(6) = standoff_Height
//    p(7) = standoff_Diameter
//    p(8) = standoff_PinDiameter
//   Optional:
//    p(9) = standoff_HoleSlack (default to 0.4)

//The following can be used to get PCB values elsewhere in the script - not in pcb definition. //If "PCB Name" is omitted then "Main" is used
//  pcbLength           --> pcbLength("PCB Name")
//  pcbWidth            --> pcbWidth("PCB Name")
//  pcbThickness        --> pcbThickness("PCB Name")
//  standoffHeight      --> standoffHeight("PCB Name")
//  standoffDiameter    --> standoffDiameter("PCB Name")
//  standoffPinDiameter --> standoffPinDiameter("PCB Name")
//  standoffHoleSlack   --> standoffHoleSlack("PCB Name")

pcb =
[
  // Default Main PCB - DO NOT REMOVE the "Main" line.
  ["Main",              pcbLength,pcbWidth,    0,0,    pcbThickness,  standoffHeight, standoffDiameter, standoffPinDiameter, standoffHoleSlack]
];
```

In the below example the cutouts, pcbStands, light tubes, pushButtons, and ridgeExtensions all use references to different PCBs.

You only have to update the pcb definition to move a PCB and all of the associated items move with it!

see examples/Multiple_PCB_v30.scad for full use. 

![image](https://github.com/mrWheel/YAPP_Box/assets/33765928/1f79e65d-6a44-4037-926d-2b20b0350c24)

The `showPCB` option now shows the PCB name on the board.