### PR TITLE
Add yappRing shape to create rings

### DIFF
--- a/YAPPgenerator_v3.scad
+++ b/YAPPgenerator_v3.scad
@@ -218,6 +218,7 @@ yappPolygon             = -30002;
 yappRoundedRect         = -30003;
 yappCircleWithFlats     = -30004;
 yappCircleWithKey       = -30005;
+yappRing                = -30006;
 
 //Shell options
 yappBoth                = -30100;
@@ -3891,6 +3892,17 @@ module generateShapeFillet (Shape, useCenter, Width, Length, Depth, filletTop, f
           translate([(useCenter) ? 0 : Radius,(useCenter) ? 0 : Radius,0])
           circle(r=Radius);
         } 
+        else if (Shape == yappRing)
+        {
+          translate([(useCenter) ? 0 : Radius,(useCenter) ? 0 : Radius,0])
+            difference() {
+                difference() {
+                    circle(r=Radius);
+                    circle(r=Length);
+                }
+                square([Width, Radius*2], center=true);
+            }
+        } 
         else if (Shape == yappRectangle)
         {
           translate([(useCenter) ? 0 : Width/2,(useCenter) ? 0 : Length/2,0])
@@ -3959,6 +3971,17 @@ module generateShape (Shape, useCenter, Width, Length, Thickness, Radius, Rotati
         {
           translate([(useCenter) ? 0 : Radius,(useCenter) ? 0 : Radius,0])
           circle(r=Radius);
+        } 
+        else if (Shape == yappRing)
+        {
+          translate([(useCenter) ? 0 : Radius,(useCenter) ? 0 : Radius,0])
+            difference() {
+                difference() {
+                    circle(r=Radius);
+                    circle(r=Length);
+                }
+                square([Width, Radius*2], center=true);
+            }
         } 
         else if (Shape == yappRectangle)
         {


### PR DESCRIPTION
@mrWheel Amazing work on this project and thank you for sharing! I needed a way to add support for a ring, let me know if this is something you would want to merge in.

This shape allows for creating cutouts in a ring shape. I am currently using it for creating an inlay in the lid, but could be used for a full cutout with a bridge to support the center of the ring. Here are a few screenshots:

Used as inlay:
![image](https://github.com/mrWheel/YAPP_Box/assets/30841716/4f3059db-6cad-4edf-a539-967c0bc3380d)


For the above screenshot it looks like this:
```
innerRadius = 11;
outerRadius = 19.5;
bridgeWidth = 0;
// Below is the entry in the lid cutout:
[pcbLength("Rotary Encoder"), pcbLength("Rotary Encoder")/2 + 4,bridgeWidth,innerRadius, outerRadius, yappRing , 1, yappCenter]
```

---
![image](https://github.com/mrWheel/YAPP_Box/assets/30841716/6f6d9f47-ff1c-433c-a80d-81705e00f5a9)


Because there is a depth that is shallower than the lid thickness this works great. For a full cutout a bridge width would be needed to support the center like so:

```
innerRadius = 11;
outerRadius = 19.5;
bridgeWidth = 0;
// Below is the entry in the lid cutout:
[pcbLength("Rotary Encoder"), pcbLength("Rotary Encoder")/2 + 4,bridgeWidth,innerRadius, outerRadius, yappRing , yappCenter]
```
