### PR TITLE
Fix bug with display pins starting position

### DIFF
--- a/YAPPgenerator_v3.scad
+++ b/YAPPgenerator_v3.scad
@@ -5535,16 +5535,16 @@ module displayMount(
             color("blue")
             {
               //--pins
-              translate([pinInsetH,pinInsetV,walltoPCBGap+lidPlaneThickness])
+              translate([pinInsetH,pinInsetV,walltoPCBGap+wallThickness])
                 cylinder (d=pinDiameter, h=pcbThickness*2);
 
-              translate([pinInsetH,displayHeight-pinInsetV,walltoPCBGap+lidPlaneThickness])
+              translate([pinInsetH,displayHeight-pinInsetV,walltoPCBGap+wallThickness])
                 cylinder (d=pinDiameter, h=pcbThickness*2);
 
-              translate([displayWidth-pinInsetH,pinInsetV,walltoPCBGap+lidPlaneThickness])
+              translate([displayWidth-pinInsetH,pinInsetV,walltoPCBGap+wallThickness])
                 cylinder (d=pinDiameter, h=pcbThickness*2);
 
-              translate([displayWidth-pinInsetH,displayHeight-pinInsetV,walltoPCBGap+lidPlaneThickness])
+              translate([displayWidth-pinInsetH,displayHeight-pinInsetV,walltoPCBGap+wallThickness])
                 cylinder (d=pinDiameter, h=pcbThickness*2);
             }// color
           } // not Self Threading


### PR DESCRIPTION
The starting position of the display pins should use wallThickness, not lidPlaneThickness

if wallThickness of the display is less than lidPlaneThickness the pins will start floating in the air:
<img width="642" height="471" alt="image" src="https://github.com/user-attachments/assets/1262c3db-6325-4577-9884-4e1d121309ff" />

Using wallThickness instead:
<img width="642" height="471" alt="image" src="https://github.com/user-attachments/assets/303c51fe-d242-4975-9edc-f651aa8dfb34" />
